### PR TITLE
Setup user interactions basics.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 default: install
 
 build:
-	go build
+	go build ./...
 
-install:
-	go install
+install: build
+	go install ./...
 
 check: build
 	go test ./...

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Please provide the following details to expedite Pull Request review:
+
+## Description of change
+
+*Please replace with a description about why this change is needed, along with a description of what changed?*
+
+## QA steps
+
+*Please replace with how we can verify that the change works?*
+

--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -1,0 +1,7 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package cmd contains everything needed for a command to function properly,
+// including providing user feedback as well as taking user input.
+//
+package cmd

--- a/cmd/interactions.go
+++ b/cmd/interactions.go
@@ -1,0 +1,52 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+)
+
+// This file contains helper functions for generic operations commonly needed
+// when implementing an interactive command.
+
+type userAbortedError string
+
+func (e userAbortedError) Error() string {
+	return string(e)
+}
+
+// IsUserAbortedError returns true if err is of type userAbortedError.
+func IsUserAbortedError(err error) bool {
+	_, ok := errors.Cause(err).(userAbortedError)
+	return ok
+}
+
+// UserConfirmYes returns an error if we do not read a "y" or "yes" from user
+// input.
+func UserConfirmYes(ctx *cmd.Context) error {
+	scanner := bufio.NewScanner(ctx.Stdin)
+	scanner.Scan()
+	err := scanner.Err()
+	if err != nil && err != io.EOF {
+		return errors.Trace(err)
+	}
+	answer := strings.ToLower(scanner.Text())
+	if answer != "y" && answer != "yes" {
+		return errors.Trace(userAbortedError("aborted"))
+	}
+	return nil
+}
+
+// Notify will post message to an io.Writer of the given cmd.Context.
+// This is provide to ensure that all message that require user attention
+// go consistently to the same writer.
+func Notify(ctx *cmd.Context, message string) {
+	fmt.Fprintf(ctx.Stdout, message)
+}

--- a/cmd/interactions.go
+++ b/cmd/interactions.go
@@ -45,7 +45,7 @@ func UserConfirmYes(ctx *cmd.Context) error {
 }
 
 // Notify will post message to an io.Writer of the given cmd.Context.
-// This is provide to ensure that all message that require user attention
+// This ensures that all message that require user attention
 // go consistently to the same writer.
 func Notify(ctx *cmd.Context, message string) {
 	fmt.Fprintf(ctx.Stdout, message)

--- a/cmd/interactions_test.go
+++ b/cmd/interactions_test.go
@@ -1,0 +1,68 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cmd_test
+
+import (
+	"bytes"
+
+	corecmd "github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju-restore/cmd"
+)
+
+type InteractionsSuite struct {
+	testing.IsolationSuite
+
+	ctx   *corecmd.Context
+	stdin bytes.Buffer
+}
+
+var _ = gc.Suite(&InteractionsSuite{})
+
+func (s *InteractionsSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.ctx = cmdtesting.Context(c)
+	s.ctx.Stdin = &s.stdin
+}
+
+func (s *InteractionsSuite) TestUserConfirmEnter(c *gc.C) {
+	s.stdin.WriteString("\n")
+	c.Assert(cmd.UserConfirmYes(s.ctx), jc.Satisfies, cmd.IsUserAbortedError)
+	c.Assert(cmdtesting.Stderr(s.ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(s.ctx), gc.Equals, "")
+}
+
+func (s *InteractionsSuite) TestUserConfirmExplicitNo(c *gc.C) {
+	s.stdin.WriteString("n")
+	c.Assert(cmd.UserConfirmYes(s.ctx), jc.Satisfies, cmd.IsUserAbortedError)
+	c.Assert(cmdtesting.Stderr(s.ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(s.ctx), gc.Equals, "")
+
+	s.stdin.WriteString("N")
+	c.Assert(cmd.UserConfirmYes(s.ctx), jc.Satisfies, cmd.IsUserAbortedError)
+	c.Assert(cmdtesting.Stderr(s.ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(s.ctx), gc.Equals, "")
+}
+
+func (s *InteractionsSuite) TestUserConfirmExplicitYes(c *gc.C) {
+	s.stdin.WriteString("y")
+	c.Assert(cmd.UserConfirmYes(s.ctx), jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(s.ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(s.ctx), gc.Equals, "")
+
+	s.stdin.WriteString("Y")
+	c.Assert(cmd.UserConfirmYes(s.ctx), jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(s.ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(s.ctx), gc.Equals, "")
+}
+
+func (s *InteractionsSuite) TestNotify(c *gc.C) {
+	cmd.Notify(s.ctx, "must be fun to be on stdout")
+	c.Assert(cmdtesting.Stderr(s.ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(s.ctx), gc.Equals, "must be fun to be on stdout")
+}

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -1,0 +1,42 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cmd
+
+import (
+	"bytes"
+	"text/template"
+
+	"github.com/juju/juju-restore/core"
+)
+
+const restoreDoc = `
+
+juju-restore must be executed on the MongoDB primary host of a Juju
+controller.
+
+The command will check the state of the target database and the
+details of the backup file provided, and restore the contents of the
+backup into the controller database.
+
+`
+
+// preChecksCompleteTemplate contains the output of all pre-check runs
+// as well as the important details of backup file that is about to be restored.
+const preChecksCompleteTemplate = `
+Replica set is healthy     ✓
+Running on primary HA node ✓
+
+All restore pre-checks are completed.
+
+The restore can now proceed.
+
+Continue [y/N]? 
+`
+
+func prechecksCompleted(prechecks *core.PrecheckResult) string {
+	t := template.Must(template.New("plugin").Parse(preChecksCompleteTemplate))
+	content := bytes.Buffer{}
+	t.Execute(&content, prechecks)
+	return content.String()
+}

--- a/cmd/package_test.go
+++ b/cmd/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cmd_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -1,0 +1,120 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cmd
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju-restore/core"
+	"github.com/juju/juju-restore/db"
+)
+
+var logger = loggo.GetLogger("juju-restore.cmd")
+
+const (
+	defaultLogConfig = "<root>=INFO"
+	verboseLogConfig = "<root>=DEBUG"
+)
+
+// NewRestoreCommand creates a cmd.Command to check the database and
+// restore the Juju backup.
+func NewRestoreCommand(ctx *cmd.Context) cmd.Command {
+	return &restoreCommand{}
+}
+
+type restoreCommand struct {
+	cmd.CommandBase
+
+	hostname string
+	port     string
+	ssl      bool
+	username string
+	password string
+
+	verbose       bool
+	loggingConfig string
+	backupFile    string
+}
+
+// Info is part of cmd.Command.
+func (c *restoreCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "juju-restore",
+		Args:    "<backup file>",
+		Purpose: "Restore a Juju backup file into a specified controller",
+		Doc:     restoreDoc,
+	}
+}
+
+// SetFlags is part of cmd.Command.
+func (c *restoreCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	f.StringVar(&c.hostname, "hostname", "localhost", "hostname of the Juju MongoDB server")
+	f.StringVar(&c.port, "port", "37017", "port of the Juju MongoDB server")
+	f.BoolVar(&c.ssl, "ssl", true, "use SSL to connect to MongoDB")
+	f.StringVar(&c.username, "username", "admin", "user for connecting to MongoDB (\"\" for no authentication)")
+	f.StringVar(&c.password, "password", "", "password for connecting to MongoDB")
+	f.StringVar(&c.loggingConfig, "logging-config", defaultLogConfig, "set logging levels")
+	f.BoolVar(&c.verbose, "verbose", false, "more output from restore (debug logging)")
+}
+
+// Init is part of cmd.Command.
+func (c *restoreCommand) Init(args []string) error {
+	if len(args) == 0 {
+		return errors.New("missing backup file")
+	}
+	c.backupFile, args = args[0], args[1:]
+	if c.verbose && c.loggingConfig != defaultLogConfig {
+		return errors.New("verbose and logging-config conflict - use one or the other")
+	}
+	if c.verbose {
+		c.loggingConfig = verboseLogConfig
+	}
+	return c.CommandBase.Init(args)
+}
+
+// Run is part of cmd.Command.
+func (c *restoreCommand) Run(ctx *cmd.Context) error {
+	err := loggo.ConfigureLoggers(c.loggingConfig)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	database, err := db.Dial(db.DialInfo{
+		Hostname: c.hostname,
+		Port:     c.port,
+		Username: c.username,
+		Password: c.password,
+		SSL:      c.ssl,
+	})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer func() {
+		err := database.Close()
+		if err != nil {
+			logger.Errorf("error while closing database: %s", err)
+		}
+	}()
+
+	restorer := core.NewRestorer(database)
+
+	// Pre-checks
+	if err := restorer.CheckDatabaseState(); err != nil {
+		return errors.Trace(err)
+	}
+
+	Notify(ctx, prechecksCompleted(&core.PrecheckResult{}))
+
+	if err := UserConfirmYes(ctx); err != nil {
+		return errors.Annotate(err, "restore operation")
+	}
+
+	// Actual restorations
+	// Post-checks
+
+	return nil
+}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -48,6 +48,11 @@ type ReplicaSetMember struct {
 	State string
 }
 
+// PrecheckResult contains the results of a pre-check run.
+type PrecheckResult struct {
+
+}
+
 // String is part of Stringer.
 func (m ReplicaSetMember) String() string {
 	return fmt.Sprintf("%d %q", m.ID, m.Name)

--- a/main.go
+++ b/main.go
@@ -6,21 +6,13 @@ package main
 import (
 	"os"
 
-	"github.com/juju/cmd"
-	"github.com/juju/errors"
-	"github.com/juju/gnuflag"
+	corecmd "github.com/juju/cmd"
 	"github.com/juju/loggo"
 
-	"github.com/juju/juju-restore/core"
-	"github.com/juju/juju-restore/db"
+	"github.com/juju/juju-restore/cmd"
 )
 
 var logger = loggo.GetLogger("juju-restore")
-
-const (
-	defaultLogConfig = "<root>=INFO"
-	verboseLogConfig = "<root>=DEBUG"
-)
 
 func main() {
 	_, err := loggo.ReplaceDefaultWriter(NewColorWriter(os.Stderr))
@@ -32,110 +24,12 @@ func main() {
 
 // Run creates and runs the restore command.
 func Run(args []string) int {
-	ctx, err := cmd.DefaultContext()
+	ctx, err := corecmd.DefaultContext()
 	if err != nil {
 		logger.Errorf("%v", err)
 		return 2
 	}
 
-	restorer := NewRestoreCommand(ctx)
-	return cmd.Main(restorer, ctx, args[1:])
+	restorer := cmd.NewRestoreCommand(ctx)
+	return corecmd.Main(restorer, ctx, args[1:])
 }
-
-// NewRestoreCommand creates a cmd.Command to check the database and
-// restore the Juju backup.
-func NewRestoreCommand(ctx *cmd.Context) cmd.Command {
-	return &restoreCommand{}
-}
-
-type restoreCommand struct {
-	cmd.CommandBase
-
-	hostname string
-	port     string
-	ssl      bool
-	username string
-	password string
-
-	verbose       bool
-	loggingConfig string
-	backupFile    string
-}
-
-// Info is part of cmd.Command.
-func (c *restoreCommand) Info() *cmd.Info {
-	return &cmd.Info{
-		Name:    "juju-restore",
-		Args:    "<backup file>",
-		Purpose: "Restore a Juju backup file into a specified controller",
-		Doc:     restoreDoc,
-	}
-}
-
-// SetFlags is part of cmd.Command.
-func (c *restoreCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.CommandBase.SetFlags(f)
-	f.StringVar(&c.hostname, "hostname", "localhost", "hostname of the Juju MongoDB server")
-	f.StringVar(&c.port, "port", "37017", "port of the Juju MongoDB server")
-	f.BoolVar(&c.ssl, "ssl", true, "use SSL to connect to MongoDB")
-	f.StringVar(&c.username, "username", "admin", "user for connecting to MongoDB (\"\" for no authentication)")
-	f.StringVar(&c.password, "password", "", "password for connecting to MongoDB")
-	f.StringVar(&c.loggingConfig, "logging-config", defaultLogConfig, "set logging levels")
-	f.BoolVar(&c.verbose, "verbose", false, "more output from restore (debug logging)")
-}
-
-// Init is part of cmd.Command.
-func (c *restoreCommand) Init(args []string) error {
-	if len(args) == 0 {
-		return errors.New("missing backup file")
-	}
-	c.backupFile, args = args[0], args[1:]
-	if c.verbose && c.loggingConfig != defaultLogConfig {
-		return errors.New("verbose and logging-config conflict - use one or the other")
-	}
-	if c.verbose {
-		c.loggingConfig = verboseLogConfig
-	}
-	return c.CommandBase.Init(args)
-}
-
-// Run is part of cmd.Command.
-func (c *restoreCommand) Run(ctx *cmd.Context) error {
-	err := loggo.ConfigureLoggers(c.loggingConfig)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	database, err := db.Dial(db.DialInfo{
-		Hostname: c.hostname,
-		Port:     c.port,
-		Username: c.username,
-		Password: c.password,
-		SSL:      c.ssl,
-	})
-	if err != nil {
-		return errors.Trace(err)
-	}
-	defer func() {
-		err := database.Close()
-		if err != nil {
-			logger.Errorf("error while closing database: %s", err)
-		}
-	}()
-
-	restorer := core.NewRestorer(database)
-	if err := restorer.CheckDatabaseState(); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
-}
-
-const restoreDoc = `
-
-juju-restore must be executed on the MongoDB primary host of a Juju
-controller.
-
-The command will check the state of the target database and the
-details of the backup file provided, and restore the contents of the
-backup into the controller database.
-
-`


### PR DESCRIPTION
Setup basics means of interacting with a user:
- provide feedback;
- confirm actions.

Added basic message to confirm that restore should proceed...

```
$ ./juju-restore --password mongo-pwd "/path/to/backup/file"

Replica set is healthy     ✓
Running on primary HA node ✓

All restore pre-checks are completed.

The restore can now proceed.

Continue [y/N]? 

ERROR restore operation: aborted

```

Refactored command related code to a dedicated package.

Added some doc and tests.

Makefile changes : 'install' target depends on 'build' and specified desired directories explicitly.

Added basic PR template to the repo.