### PR TITLE
Check node connectivity. Streamline user feedback as run proceeds.

### DIFF
--- a/cmd/interactions.go
+++ b/cmd/interactions.go
@@ -28,25 +28,53 @@ func IsUserAbortedError(err error) bool {
 	return ok
 }
 
+// NewUserInteractions constructs user interactions with given context.
+func NewUserInteractions(ctx *cmd.Context) *UserInteractions {
+	return &UserInteractions{ctx}
+}
+
+// UserInteractions communicates with the user
+// by providing feedback and by collecting user input.
+type UserInteractions struct {
+	ctx *cmd.Context
+}
+
 // UserConfirmYes returns an error if we do not read a "y" or "yes" from user
 // input.
-func UserConfirmYes(ctx *cmd.Context) error {
-	scanner := bufio.NewScanner(ctx.Stdin)
-	scanner.Scan()
-	err := scanner.Err()
-	if err != nil && err != io.EOF {
-		return errors.Trace(err)
+func (ui *UserInteractions) UserConfirmYes() error {
+	scanner := bufio.NewScanner(byteAtATimeReader{ui.ctx.Stdin})
+	done := !scanner.Scan()
+	if done {
+		if err := scanner.Err(); err != nil {
+			return errors.Trace(err)
+		}
 	}
+
 	answer := strings.ToLower(scanner.Text())
-	if answer != "y" && answer != "yes" {
+	if done && answer == "" {
+		return io.EOF
+	}
+	if answer != "y" {
 		return errors.Trace(userAbortedError("aborted"))
 	}
 	return nil
 }
 
 // Notify will post message to an io.Writer of the given cmd.Context.
-// This ensures that all message that require user attention
+// This ensures that all messages that require user attention
 // go consistently to the same writer.
-func Notify(ctx *cmd.Context, message string) {
-	fmt.Fprintf(ctx.Stdout, message)
+func (ui *UserInteractions) Notify(message string) {
+	fmt.Fprintf(ui.ctx.Stdout, message)
+}
+
+// byteAtATimeReader causes all reads to return a single byte.  This prevents
+// things line bufio.scanner from reading past the end of a line, which can
+// cause problems when we do wacky things like reading directly from the
+// terminal for password style prompts.
+type byteAtATimeReader struct {
+	io.Reader
+}
+
+func (r byteAtATimeReader) Read(out []byte) (int, error) {
+	return r.Reader.Read(out[:1])
 }

--- a/cmd/interactions_test.go
+++ b/cmd/interactions_test.go
@@ -20,6 +20,7 @@ type InteractionsSuite struct {
 
 	ctx   *corecmd.Context
 	stdin bytes.Buffer
+	ui    *cmd.UserInteractions
 }
 
 var _ = gc.Suite(&InteractionsSuite{})
@@ -28,41 +29,42 @@ func (s *InteractionsSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.ctx = cmdtesting.Context(c)
 	s.ctx.Stdin = &s.stdin
+	s.ui = cmd.NewUserInteractions(s.ctx)
 }
 
 func (s *InteractionsSuite) TestUserConfirmEnter(c *gc.C) {
 	s.stdin.WriteString("\n")
-	c.Assert(cmd.UserConfirmYes(s.ctx), jc.Satisfies, cmd.IsUserAbortedError)
+	c.Assert(s.ui.UserConfirmYes(), jc.Satisfies, cmd.IsUserAbortedError)
 	c.Assert(cmdtesting.Stderr(s.ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(s.ctx), gc.Equals, "")
 }
 
 func (s *InteractionsSuite) TestUserConfirmExplicitNo(c *gc.C) {
 	s.stdin.WriteString("n")
-	c.Assert(cmd.UserConfirmYes(s.ctx), jc.Satisfies, cmd.IsUserAbortedError)
+	c.Assert(s.ui.UserConfirmYes(), jc.Satisfies, cmd.IsUserAbortedError)
 	c.Assert(cmdtesting.Stderr(s.ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(s.ctx), gc.Equals, "")
 
 	s.stdin.WriteString("N")
-	c.Assert(cmd.UserConfirmYes(s.ctx), jc.Satisfies, cmd.IsUserAbortedError)
+	c.Assert(s.ui.UserConfirmYes(), jc.Satisfies, cmd.IsUserAbortedError)
 	c.Assert(cmdtesting.Stderr(s.ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(s.ctx), gc.Equals, "")
 }
 
 func (s *InteractionsSuite) TestUserConfirmExplicitYes(c *gc.C) {
 	s.stdin.WriteString("y")
-	c.Assert(cmd.UserConfirmYes(s.ctx), jc.ErrorIsNil)
+	c.Assert(s.ui.UserConfirmYes(), jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(s.ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(s.ctx), gc.Equals, "")
 
 	s.stdin.WriteString("Y")
-	c.Assert(cmd.UserConfirmYes(s.ctx), jc.ErrorIsNil)
+	c.Assert(s.ui.UserConfirmYes(), jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(s.ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(s.ctx), gc.Equals, "")
 }
 
 func (s *InteractionsSuite) TestNotify(c *gc.C) {
-	cmd.Notify(s.ctx, "must be fun to be on stdout")
+	s.ui.Notify("must be fun to be on stdout")
 	c.Assert(cmdtesting.Stderr(s.ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(s.ctx), gc.Equals, "must be fun to be on stdout")
 }

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -6,11 +6,10 @@ package cmd
 import (
 	"bytes"
 	"text/template"
-
-	"github.com/juju/juju-restore/core"
 )
 
-const restoreDoc = `
+const (
+	restoreDoc = `
 
 juju-restore must be executed on the MongoDB primary host of a Juju
 controller.
@@ -21,24 +20,47 @@ backup into the controller database.
 
 `
 
-// preChecksCompleteTemplate contains the output of all pre-check runs
-// as well as the important details of backup file that is about to be restored.
-const preChecksCompleteTemplate = `
+	dbHealthComplete = `
 Replica set is healthy     ✓
 Running on primary HA node ✓
+`
 
-All restore pre-checks are completed.
+	releaseAgentsControl = `
+This controller is in HA and to restore into it successfully, 
+'juju-restore' needs to manage Juju and Mongo agents on  
+secondary controller nodes.
+However, on the bigger systems, the operator might want to manage 
+these agents manually.
 
+Do you want 'juju-restore' to manage these agents automatically? (y/N): `
+
+	nodeConnectivityTemplate = `{{range $k,$v := . }} 
+    {{$k}} {{if $v}}✗ error: {{ $v }}{{else}}✓ {{end}}{{end}}
+`
+
+	backupFileTemplate = `
 You are about to restore a controller from a backup file taken on {{.BackupDate}}. 
 It contains a controller {{.ControllerUUID}} at Juju version {{.JujuVersion}} with {{.ModelCount}} models.
+`
+
+	preChecksCompleted = `
+All restore pre-checks are completed.
 
 Restore cannot be cleanly aborted from here on.
 
 Are you sure you want to proceed? (y/N): `
 
-func prechecksCompleted(prechecks *core.PrecheckResult) string {
-	t := template.Must(template.New("plugin").Parse(preChecksCompleteTemplate))
+	secondaryAgentsMustStop = `
+Juju agents and mongo agents on secondary controller machines must be stopped by this point.
+To stop the agents, login into each secondary controller and run:
+    $ systemctl stop jujud-machine-*
+    $ systemctl stop juju-db
+`
+)
+
+func populate(aTemplate string, data interface{}) string {
+	t := template.Must(template.New("fragment").Parse(aTemplate))
 	content := bytes.Buffer{}
-	t.Execute(&content, prechecks)
+	t.Execute(&content, data)
 	return content.String()
 }

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju-restore/cmd"
 	"github.com/juju/juju-restore/core"
 	"github.com/juju/juju-restore/db"
+	"github.com/juju/juju-restore/machine"
 )
 
 type restoreSuite struct {
@@ -48,7 +49,7 @@ func (s *restoreSuite) SetUpTest(c *gc.C) {
 		},
 	}
 	s.connectF = func(db.DialInfo) (core.Database, error) { return s.database, nil }
-	s.converter = core.ControllerNodeForReplicaSetMember
+	s.converter = machine.ControllerNodeForReplicaSetMember
 
 	s.command = cmd.NewRestoreCommand(s.connectF, s.converter)
 }

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -4,6 +4,7 @@
 package cmd_test
 
 import (
+	"github.com/juju/errors"
 	"strings"
 
 	corecmd "github.com/juju/cmd"
@@ -20,9 +21,10 @@ import (
 type restoreSuite struct {
 	testing.IsolationSuite
 
-	command  corecmd.Command
-	database *testDatabase
-	connectF func(db.DialInfo) (core.Database, error)
+	command   corecmd.Command
+	database  *testDatabase
+	connectF  func(db.DialInfo) (core.Database, error)
+	converter func(member core.ReplicaSetMember) core.ControllerNode
 }
 
 var _ = gc.Suite(&restoreSuite{})
@@ -46,8 +48,9 @@ func (s *restoreSuite) SetUpTest(c *gc.C) {
 		},
 	}
 	s.connectF = func(db.DialInfo) (core.Database, error) { return s.database, nil }
+	s.converter = core.ControllerNodeForReplicaSetMember
 
-	s.command = cmd.NewRestoreCommand(s.connectF)
+	s.command = cmd.NewRestoreCommand(s.connectF, s.converter)
 }
 
 type restoreCommandTestData struct {
@@ -92,14 +95,15 @@ func (s *restoreSuite) TestRestoreAborted(c *gc.C) {
 	s.database.CheckCallNames(c, "ReplicaSet", "Close")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+Checking database and replica set health...
 
 Replica set is healthy     ✓
 Running on primary HA node ✓
 
-All restore pre-checks are completed.
-
 You are about to restore a controller from a backup file taken on 0001-01-01 00:00:00 +0000 UTC. 
 It contains a controller  at Juju version 0.0.0 with 0 models.
+
+All restore pre-checks are completed.
 
 Restore cannot be cleanly aborted from here on.
 
@@ -113,14 +117,170 @@ func (s *restoreSuite) TestRestoreProceed(c *gc.C) {
 	s.database.CheckCallNames(c, "ReplicaSet", "Close")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+Checking database and replica set health...
 
 Replica set is healthy     ✓
 Running on primary HA node ✓
 
+You are about to restore a controller from a backup file taken on 0001-01-01 00:00:00 +0000 UTC. 
+It contains a controller  at Juju version 0.0.0 with 0 models.
+
 All restore pre-checks are completed.
+
+Restore cannot be cleanly aborted from here on.
+
+Are you sure you want to proceed? (y/N): `[1:])
+}
+
+func (s *restoreSuite) setupHA() {
+	s.database.replicaSetF = func() (core.ReplicaSet, error) {
+		return core.ReplicaSet{
+			Members: []core.ReplicaSetMember{
+				{
+					Healthy: true,
+					ID:      1,
+					Name:    "one:node",
+					State:   "PRIMARY",
+					Self:    true,
+				},
+				{
+					Healthy: true,
+					ID:      2,
+					Name:    "two:node",
+					State:   "SECONDARY",
+				},
+			},
+		}, nil
+	}
+}
+
+func (s *restoreSuite) TestRestoreHAConnectionFail(c *gc.C) {
+	s.setupHA()
+	s.converter = func(member core.ReplicaSetMember) core.ControllerNode {
+		node := &fakeControllerNode{Stub: &testing.Stub{}, ip: member.Name}
+		node.SetErrors(errors.New("kaboom"))
+		return node
+	}
+	s.command = cmd.NewRestoreCommand(s.connectF, s.converter)
+	ctx, err := s.runCmd(c, "y\r\n", "backup.file")
+	c.Assert(err, gc.ErrorMatches, `'juju-restore' could not connect to all controller machines: controllers' agents cannot be managed`)
+
+	s.database.CheckCallNames(c, "ReplicaSet", "Close")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+Checking database and replica set health...
+
+Replica set is healthy     ✓
+Running on primary HA node ✓
 
 You are about to restore a controller from a backup file taken on 0001-01-01 00:00:00 +0000 UTC. 
 It contains a controller  at Juju version 0.0.0 with 0 models.
+
+This controller is in HA and to restore into it successfully, 
+'juju-restore' needs to manage Juju and Mongo agents on  
+secondary controller nodes.
+However, on the bigger systems, the operator might want to manage 
+these agents manually.
+
+Do you want 'juju-restore' to manage these agents automatically? (y/N): 
+
+Checking connectivity to secondary controller machines...
+ 
+    two:node ✗ error: kaboom
+`[1:])
+}
+
+func (s *restoreSuite) TestRestoreHAConnectionOk(c *gc.C) {
+	s.setupHA()
+	s.converter = func(member core.ReplicaSetMember) core.ControllerNode {
+		return &fakeControllerNode{Stub: &testing.Stub{}, ip: member.Name}
+	}
+	s.command = cmd.NewRestoreCommand(s.connectF, s.converter)
+	ctx, err := s.runCmd(c, "y\r\n\n", "backup.file")
+	c.Assert(err, gc.ErrorMatches, "restore operation: aborted")
+
+	s.database.CheckCallNames(c, "ReplicaSet", "Close")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+Checking database and replica set health...
+
+Replica set is healthy     ✓
+Running on primary HA node ✓
+
+You are about to restore a controller from a backup file taken on 0001-01-01 00:00:00 +0000 UTC. 
+It contains a controller  at Juju version 0.0.0 with 0 models.
+
+This controller is in HA and to restore into it successfully, 
+'juju-restore' needs to manage Juju and Mongo agents on  
+secondary controller nodes.
+However, on the bigger systems, the operator might want to manage 
+these agents manually.
+
+Do you want 'juju-restore' to manage these agents automatically? (y/N): 
+
+Checking connectivity to secondary controller machines...
+ 
+    two:node ✓ 
+
+All restore pre-checks are completed.
+
+Restore cannot be cleanly aborted from here on.
+
+Are you sure you want to proceed? (y/N): `[1:])
+}
+
+func (s *restoreSuite) TestRestoreHAChoseManual(c *gc.C) {
+	s.setupHA()
+	ctx, err := s.runCmd(c, "\n\n", "backup.file")
+	c.Assert(err, gc.ErrorMatches, "restore operation: aborted")
+
+	s.database.CheckCallNames(c, "ReplicaSet", "Close")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+Checking database and replica set health...
+
+Replica set is healthy     ✓
+Running on primary HA node ✓
+
+You are about to restore a controller from a backup file taken on 0001-01-01 00:00:00 +0000 UTC. 
+It contains a controller  at Juju version 0.0.0 with 0 models.
+
+This controller is in HA and to restore into it successfully, 
+'juju-restore' needs to manage Juju and Mongo agents on  
+secondary controller nodes.
+However, on the bigger systems, the operator might want to manage 
+these agents manually.
+
+Do you want 'juju-restore' to manage these agents automatically? (y/N): 
+All restore pre-checks are completed.
+
+Restore cannot be cleanly aborted from here on.
+
+Are you sure you want to proceed? (y/N): `[1:])
+}
+
+func (s *restoreSuite) TestRestoreHAManualControlOption(c *gc.C) {
+	s.setupHA()
+	ctx, err := s.runCmd(c, "y\r\ny\r\n", "backup.file", "--manual-agent-control")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.database.CheckCallNames(c, "ReplicaSet", "Close")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+Checking database and replica set health...
+
+Replica set is healthy     ✓
+Running on primary HA node ✓
+
+You are about to restore a controller from a backup file taken on 0001-01-01 00:00:00 +0000 UTC. 
+It contains a controller  at Juju version 0.0.0 with 0 models.
+
+Juju agents and mongo agents on secondary controller machines must be stopped by this point.
+To stop the agents, login into each secondary controller and run:
+    $ systemctl stop jujud-machine-*
+    $ systemctl stop juju-db
+
+All restore pre-checks are completed.
 
 Restore cannot be cleanly aborted from here on.
 
@@ -150,4 +310,19 @@ func (d *testDatabase) ReplicaSet() (core.ReplicaSet, error) {
 
 func (d *testDatabase) Close() {
 	d.AddCall("Close")
+}
+
+type fakeControllerNode struct {
+	*testing.Stub
+	ip string
+}
+
+func (f *fakeControllerNode) IP() string {
+	f.Stub.MethodCall(f, "IP")
+	return f.ip
+}
+
+func (f *fakeControllerNode) Ping() error {
+	f.Stub.MethodCall(f, "Ping")
+	return f.NextErr()
 }

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -4,11 +4,11 @@
 package cmd_test
 
 import (
-	"github.com/juju/errors"
 	"strings"
 
 	corecmd "github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -31,7 +31,7 @@ type ReplicaSet struct {
 	Members []ReplicaSetMember
 }
 
-// ReplicaSetMember holds status informatian about a database replica
+// ReplicaSetMember holds status information about a database replica
 // set member.
 type ReplicaSetMember struct {
 	// ID is unique across the nodes.
@@ -54,6 +54,20 @@ type ReplicaSetMember struct {
 	State string
 }
 
+// ControllerNode defines behavior for a controller node machine.
+type ControllerNode interface {
+	// IP returns IP address of the machine.
+	IP() string
+
+	// Ping checks connection to the controller machine.
+	Ping() error
+}
+
+// String is part of Stringer.
+func (m ReplicaSetMember) String() string {
+	return fmt.Sprintf("%d %q", m.ID, m.Name)
+}
+
 // PrecheckResult contains the results of a pre-check run.
 type PrecheckResult struct {
 	// BackupDate is the date the backup was finished.
@@ -67,11 +81,6 @@ type PrecheckResult struct {
 
 	// ModelCount is the count of models that this backup contains.
 	ModelCount int64
-}
-
-// String is part of Stringer.
-func (m ReplicaSetMember) String() string {
-	return fmt.Sprintf("%d %q", m.ID, m.Name)
 }
 
 const (

--- a/core/restorer.go
+++ b/core/restorer.go
@@ -4,38 +4,42 @@
 package core
 
 import (
+	"strings"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/kr/pretty"
+
+	"github.com/juju/juju-restore/machine"
 )
 
 var logger = loggo.GetLogger("juju-restore.core")
 
 // NewRestorer returns a new restorer for a specific database and
 // backup.
-func NewRestorer(db Database) *Restorer {
-	return &Restorer{db: db}
+func NewRestorer(db Database, convert func(member ReplicaSetMember) ControllerNode) (*Restorer, error) {
+	replicaSet, err := db.ReplicaSet()
+	if err != nil {
+		return nil, errors.Annotate(err, "getting database replica set")
+	}
+	return &Restorer{db, replicaSet, convert}, nil
 }
 
 // Restorer checks the database health and backup file state and
 // restores the backup file.
 type Restorer struct {
-	db Database
+	db                      Database
+	replicaSet              ReplicaSet
+	convertToControllerNode func(member ReplicaSetMember) ControllerNode
 }
 
 // CheckDatabaseState determines whether this database is appropriate
 // for restoring into.
 func (r *Restorer) CheckDatabaseState() error {
-	replicaSet, err := r.db.ReplicaSet()
-	if err != nil {
-		return errors.Annotate(err, "getting database replica set")
-	}
-
-	logger.Debugf("replicaset status: %s", pretty.Sprint(replicaSet))
-
+	logger.Debugf("replicaset status: %s", pretty.Sprint(r.replicaSet))
 	var primary *ReplicaSetMember
 	var unhealthyMembers []ReplicaSetMember
-	for _, member := range replicaSet.Members {
+	for _, member := range r.replicaSet.Members {
 		if member.State == statePrimary {
 			// We need to put member into a new variable, otherwise
 			// the value pointed at by primary will be overwritten the
@@ -58,6 +62,31 @@ func (r *Restorer) CheckDatabaseState() error {
 	if !primary.Self {
 		return errors.Errorf("not running on primary replica set member, primary is %s", primary)
 	}
-
 	return nil
+}
+
+// IsHA returns true of there is more than one member in replica set.
+func (r *Restorer) IsHA() bool {
+	return len(r.replicaSet.Members) > 1
+}
+
+// CheckSecondaryControllerNodes determines whether secondary controller nodes can be reached.
+func (r *Restorer) CheckSecondaryControllerNodes() map[string]error {
+	reachable := map[string]error{}
+	for _, member := range r.replicaSet.Members {
+		if member.Self {
+			// We are already on this machine, so no need to check connectivity.
+			continue
+		}
+		memberMachine := r.convertToControllerNode(member)
+		reachable[memberMachine.IP()] = memberMachine.Ping()
+	}
+	return reachable
+}
+
+// ControllerNodeForReplicaSetMember returns ControllerNode for ReplicaSetMember.
+func ControllerNodeForReplicaSetMember(member ReplicaSetMember) ControllerNode {
+	//	Replica set member name is in the form <machine IP>:<Mongo port>.
+	ip := member.Name[:strings.Index(member.Name, ":")]
+	return machine.NewMachine(ip)
 }

--- a/core/restorer.go
+++ b/core/restorer.go
@@ -4,13 +4,9 @@
 package core
 
 import (
-	"strings"
-
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/kr/pretty"
-
-	"github.com/juju/juju-restore/machine"
 )
 
 var logger = loggo.GetLogger("juju-restore.core")
@@ -82,11 +78,4 @@ func (r *Restorer) CheckSecondaryControllerNodes() map[string]error {
 		reachable[memberMachine.IP()] = memberMachine.Ping()
 	}
 	return reachable
-}
-
-// ControllerNodeForReplicaSetMember returns ControllerNode for ReplicaSetMember.
-func ControllerNodeForReplicaSetMember(member ReplicaSetMember) ControllerNode {
-	//	Replica set member name is in the form <machine IP>:<Mongo port>.
-	ip := member.Name[:strings.Index(member.Name, ":")]
-	return machine.NewMachine(ip)
 }

--- a/core/restorer_test.go
+++ b/core/restorer_test.go
@@ -4,6 +4,7 @@
 package core_test
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -13,12 +14,18 @@ import (
 
 type restorerSuite struct {
 	testing.IsolationSuite
+	converter func(member core.ReplicaSetMember) core.ControllerNode
 }
 
 var _ = gc.Suite(&restorerSuite{})
 
+func (s *restorerSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.converter = core.ControllerNodeForReplicaSetMember
+}
+
 func (s *restorerSuite) TestCheckDatabaseStateUnhealthyMembers(c *gc.C) {
-	r := core.NewRestorer(&fakeDatabase{
+	r, err := core.NewRestorer(&fakeDatabase{
 		replicaSetF: func() (core.ReplicaSet, error) {
 			return core.ReplicaSet{
 				Members: []core.ReplicaSetMember{{
@@ -39,15 +46,15 @@ func (s *restorerSuite) TestCheckDatabaseStateUnhealthyMembers(c *gc.C) {
 				}},
 			}, nil
 		},
-	})
-
-	err := r.CheckDatabaseState()
+	}, s.converter)
+	c.Assert(err, jc.ErrorIsNil)
+	err = r.CheckDatabaseState()
 	c.Assert(err, jc.Satisfies, core.IsUnhealthyMembersError)
 	c.Assert(err, gc.ErrorMatches, `unhealthy replica set members: 1 "kaira-ba", 3 "bibi"`)
 }
 
 func (s *restorerSuite) TestCheckDatabaseStateNoPrimary(c *gc.C) {
-	r := core.NewRestorer(&fakeDatabase{
+	r, err := core.NewRestorer(&fakeDatabase{
 		replicaSetF: func() (core.ReplicaSet, error) {
 			return core.ReplicaSet{
 				Members: []core.ReplicaSetMember{{
@@ -68,13 +75,14 @@ func (s *restorerSuite) TestCheckDatabaseStateNoPrimary(c *gc.C) {
 				}},
 			}, nil
 		},
-	})
-	err := r.CheckDatabaseState()
+	}, s.converter)
+	c.Assert(err, jc.ErrorIsNil)
+	err = r.CheckDatabaseState()
 	c.Assert(err, gc.ErrorMatches, "no primary found in replica set")
 }
 
 func (s *restorerSuite) TestCheckDatabaseStateNotPrimary(c *gc.C) {
-	r := core.NewRestorer(&fakeDatabase{
+	r, err := core.NewRestorer(&fakeDatabase{
 		replicaSetF: func() (core.ReplicaSet, error) {
 			return core.ReplicaSet{
 				Members: []core.ReplicaSetMember{{
@@ -96,13 +104,14 @@ func (s *restorerSuite) TestCheckDatabaseStateNotPrimary(c *gc.C) {
 				}},
 			}, nil
 		},
-	})
-	err := r.CheckDatabaseState()
+	}, s.converter)
+	c.Assert(err, jc.ErrorIsNil)
+	err = r.CheckDatabaseState()
 	c.Assert(err, gc.ErrorMatches, `not running on primary replica set member, primary is 2 "djula"`)
 }
 
 func (s *restorerSuite) TestCheckDatabaseStateAllGood(c *gc.C) {
-	r := core.NewRestorer(&fakeDatabase{
+	r, err := core.NewRestorer(&fakeDatabase{
 		replicaSetF: func() (core.ReplicaSet, error) {
 			return core.ReplicaSet{
 				Members: []core.ReplicaSetMember{{
@@ -124,13 +133,15 @@ func (s *restorerSuite) TestCheckDatabaseStateAllGood(c *gc.C) {
 				}},
 			}, nil
 		},
-	})
-	err := r.CheckDatabaseState()
+	}, s.converter)
 	c.Assert(err, jc.ErrorIsNil)
+	err = r.CheckDatabaseState()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r.IsHA(), jc.IsTrue)
 }
 
 func (s *restorerSuite) TestCheckDatabaseStateOneMember(c *gc.C) {
-	r := core.NewRestorer(&fakeDatabase{
+	r, err := core.NewRestorer(&fakeDatabase{
 		replicaSetF: func() (core.ReplicaSet, error) {
 			return core.ReplicaSet{
 				Members: []core.ReplicaSetMember{{
@@ -142,9 +153,74 @@ func (s *restorerSuite) TestCheckDatabaseStateOneMember(c *gc.C) {
 				}},
 			}, nil
 		},
-	})
-	err := r.CheckDatabaseState()
+	}, s.converter)
 	c.Assert(err, jc.ErrorIsNil)
+	err = r.CheckDatabaseState()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r.IsHA(), jc.IsFalse)
+}
+
+func (s *restorerSuite) TestCheckSecondaryControllerNodesSkipsSelf(c *gc.C) {
+	r, err := core.NewRestorer(&fakeDatabase{
+		replicaSetF: func() (core.ReplicaSet, error) {
+			return core.ReplicaSet{
+				Members: []core.ReplicaSetMember{
+					{
+						Healthy: true,
+						ID:      2,
+						Name:    "djula:wot",
+						State:   "PRIMARY",
+						Self:    true,
+					},
+				},
+			}, nil
+		},
+	}, s.converter)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r.CheckSecondaryControllerNodes(), gc.DeepEquals, map[string]error{})
+}
+
+func (s *restorerSuite) checkSecondaryControllerNodes(c *gc.C, expected map[string]error) {
+	r, err := core.NewRestorer(&fakeDatabase{
+		replicaSetF: func() (core.ReplicaSet, error) {
+			return core.ReplicaSet{
+				Members: []core.ReplicaSetMember{
+					{
+						Healthy: true,
+						ID:      2,
+						Name:    "djula",
+						State:   "PRIMARY",
+						Self:    true,
+					},
+					{
+						Healthy: true,
+						ID:      1,
+						Name:    "wot",
+						State:   "SECONDARY",
+					},
+				},
+			}, nil
+		},
+	}, s.converter)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r.CheckSecondaryControllerNodes(), gc.DeepEquals, expected)
+}
+
+func (s *restorerSuite) TestCheckSecondaryControllerNodesOk(c *gc.C) {
+	s.converter = func(member core.ReplicaSetMember) core.ControllerNode {
+		return &fakeControllerNode{Stub: &testing.Stub{}, ip: member.Name}
+	}
+	s.checkSecondaryControllerNodes(c, map[string]error{"wot": nil})
+}
+
+func (s *restorerSuite) TestCheckSecondaryControllerNodesFail(c *gc.C) {
+	err := errors.New("boom")
+	s.converter = func(member core.ReplicaSetMember) core.ControllerNode {
+		node := &fakeControllerNode{Stub: &testing.Stub{}, ip: member.Name}
+		node.SetErrors(err)
+		return node
+	}
+	s.checkSecondaryControllerNodes(c, map[string]error{"wot": err})
 }
 
 type fakeDatabase struct {
@@ -159,4 +235,19 @@ func (db *fakeDatabase) ReplicaSet() (core.ReplicaSet, error) {
 
 func (db *fakeDatabase) Close() {
 	db.Stub.MethodCall(db, "Close")
+}
+
+type fakeControllerNode struct {
+	*testing.Stub
+	ip string
+}
+
+func (f *fakeControllerNode) IP() string {
+	f.Stub.MethodCall(f, "IP")
+	return f.ip
+}
+
+func (f *fakeControllerNode) Ping() error {
+	f.Stub.MethodCall(f, "Ping")
+	return f.NextErr()
 }

--- a/core/restorer_test.go
+++ b/core/restorer_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju-restore/core"
+	"github.com/juju/juju-restore/machine"
 )
 
 type restorerSuite struct {
@@ -21,7 +22,7 @@ var _ = gc.Suite(&restorerSuite{})
 
 func (s *restorerSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
-	s.converter = core.ControllerNodeForReplicaSetMember
+	s.converter = machine.ControllerNodeForReplicaSetMember
 }
 
 func (s *restorerSuite) TestCheckDatabaseStateUnhealthyMembers(c *gc.C) {

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -18,15 +18,15 @@ import (
 func ControllerNodeForReplicaSetMember(member core.ReplicaSetMember) core.ControllerNode {
 	//	Replica set member name is in the form <machine IP>:<Mongo port>.
 	ip := member.Name[:strings.Index(member.Name, ":")]
-	return NewMachine(ip)
+	return New(ip)
 }
 
 type Machine struct {
 	ip string
 }
 
-// NewMachine returns a machine that satisfies core.ControllerNode.
-func NewMachine(ip string) *Machine {
+// New returns a machine that satisfies core.ControllerNode.
+func New(ip string) *Machine {
 	return &Machine{ip}
 }
 

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -1,0 +1,73 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+
+	"github.com/juju/errors"
+)
+
+type Machine struct {
+	ip string
+}
+
+// NewMachine returns a machine that satisfies core.ControllerNode.
+func NewMachine(ip string) *Machine {
+	return &Machine{ip}
+}
+
+// IP implements ControllerNode.IP.
+func (r *Machine) IP() string {
+	return r.ip
+}
+
+// Ping implements ControllerNode.Ping()
+// by ssh'ing into the machine and executing an 'echo' command.
+func (r *Machine) Ping() error {
+	command := fmt.Sprintf("hello from %v", r.IP())
+	out, err := runRemoteCommand(r, "echo", command)
+	if err != nil {
+		return err
+	}
+	// echo will add a carriage return, \r\n
+	expectedOut := fmt.Sprintf("%v\r\n", command)
+	if out != expectedOut {
+		return errors.Errorf("ping controller machine %v failed: expected %q, got %q", r.IP(), expectedOut, out)
+	}
+	return nil
+}
+
+// runRemoteCommand takes in a command and runs it remotely using ssh.
+// All strings within the command must be individually passed-in.
+// For example,
+//     to run 'echo hi:D', pass in "echo", "hi:D",
+//     to stop juju-db, pass in "systemctl", "stop", "juju-db".
+var runRemoteCommand = func(r *Machine, commands ...string) (string, error) {
+	args := []string{
+		"ssh",
+		"-o", "StrictHostKeyChecking no",
+		"-t", "-t", // twice to force tty allocation, even if ssh jas no local tty
+		"-i", "/var/lib/juju/system-identity",
+		fmt.Sprintf("ubuntu@%v", r.IP()),
+	}
+	args = append(args, commands...)
+	// Since we are on the primary controller node, logged in as a 'ubuntu' user,
+	// we need to run in sudo to switch to 'root' user to elevate privileges
+	// since only root can read /var/lib/juju/system-identity.
+	customSSH := exec.Command("sudo", args...)
+	var out bytes.Buffer
+	customSSH.Stdout = &out
+	cmdErr := bytes.Buffer{}
+	customSSH.Stderr = &cmdErr
+	if err := customSSH.Run(); err != nil {
+		if cmdErr.Len() > 0 {
+			return "", errors.New(cmdErr.String())
+		}
+		return "", err
+	}
+	return out.String(), nil
+}

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -7,9 +7,19 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/juju/errors"
+
+	"github.com/juju/juju-restore/core"
 )
+
+// ControllerNodeForReplicaSetMember returns ControllerNode for ReplicaSetMember.
+func ControllerNodeForReplicaSetMember(member core.ReplicaSetMember) core.ControllerNode {
+	//	Replica set member name is in the form <machine IP>:<Mongo port>.
+	ip := member.Name[:strings.Index(member.Name, ":")]
+	return NewMachine(ip)
+}
 
 type Machine struct {
 	ip string

--- a/main.go
+++ b/main.go
@@ -10,8 +10,8 @@ import (
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju-restore/cmd"
-	"github.com/juju/juju-restore/machine"
 	"github.com/juju/juju-restore/db"
+	"github.com/juju/juju-restore/machine"
 )
 
 var logger = loggo.GetLogger("juju-restore")

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju-restore/cmd"
+	"github.com/juju/juju-restore/core"
 	"github.com/juju/juju-restore/db"
 )
 
@@ -31,6 +32,6 @@ func Run(args []string) int {
 		return 2
 	}
 
-	restorer := cmd.NewRestoreCommand(db.Dial)
+	restorer := cmd.NewRestoreCommand(db.Dial, core.ControllerNodeForReplicaSetMember)
 	return corecmd.Main(restorer, ctx, args[1:])
 }

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju-restore/cmd"
-	"github.com/juju/juju-restore/core"
+	"github.com/juju/juju-restore/machine"
 	"github.com/juju/juju-restore/db"
 )
 
@@ -32,6 +32,6 @@ func Run(args []string) int {
 		return 2
 	}
 
-	restorer := cmd.NewRestoreCommand(db.Dial, core.ControllerNodeForReplicaSetMember)
+	restorer := cmd.NewRestoreCommand(db.Dial, machine.ControllerNodeForReplicaSetMember)
 	return corecmd.Main(restorer, ctx, args[1:])
 }


### PR DESCRIPTION
## Description of change

Added option to allow for manual management of agents on secondary controller machines.
If the option is not provided, the user is prompted to confirm that 'juju-restore' should manage these agents . 
If the user confirms, we check if we can connect to these controller machines. If we cannot connect to at least one machine, restore is aborted with appropriate message.
If the user declines, we let them know that they need to ensure that agents need to be stopped on secondary machines.

## QA steps

1. bootstrap and enable HA
2. Run 'juju-restore' on primary machine with and without the option.

