### PR TITLE
Manage Juju agents.

### DIFF
--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -34,7 +34,7 @@ these agents manually.
 
 Do you want 'juju-restore' to manage these agents automatically? (y/N): `
 
-	nodeConnectivityTemplate = `{{range $k,$v := . }} 
+	nodesTemplate = `{{range $k,$v := . }} 
     {{$k}} {{if $v}}✗ error: {{ $v }}{{else}}✓ {{end}}{{end}}
 `
 
@@ -51,10 +51,9 @@ Restore cannot be cleanly aborted from here on.
 Are you sure you want to proceed? (y/N): `
 
 	secondaryAgentsMustStop = `
-Juju agents and mongo agents on secondary controller machines must be stopped by this point.
+Juju agents on secondary controller machines must be stopped by this point.
 To stop the agents, login into each secondary controller and run:
     $ systemctl stop jujud-machine-*
-    $ systemctl stop juju-db
 `
 )
 

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -60,6 +60,11 @@ type restoreCommand struct {
 	restorer    *core.Restorer
 	converter   func(member core.ReplicaSetMember) core.ControllerNode
 	readOneChar func(*cmd.Context) (string, error)
+
+	// To be used as an option during development to enable an easier way to re-start
+	// all agents in HA federation.
+	// XXXXXXXXXXXXX Remove ME
+	restart bool
 }
 
 // Info is part of cmd.Command.
@@ -82,7 +87,8 @@ func (c *restoreCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.password, "password", "", "password for connecting to MongoDB")
 	f.StringVar(&c.loggingConfig, "logging-config", defaultLogConfig, "set logging levels")
 	f.BoolVar(&c.verbose, "verbose", false, "more output from restore (debug logging)")
-	f.BoolVar(&c.manualAgentControl, "manual-agent-control", false, "operator stops/starts Juju and Mongo agents on secondary controller nodes in HA")
+	f.BoolVar(&c.manualAgentControl, "manual-agent-control", false, "operator manages secondary controller nodes in HA, e.g stops/starts Juju and Mongo agents")
+	f.BoolVar(&c.restart, "rs", false, "REMOVE ME")
 }
 
 // Init is part of cmd.Command.
@@ -106,6 +112,8 @@ func (c *restoreCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	c.ui = NewUserInteractions(ctx, c.readOneChar)
+	c.ui.Notify("Connecting to database...\n")
 	database, err := c.connect(db.DialInfo{
 		Hostname: c.hostname,
 		Port:     c.port,
@@ -123,15 +131,19 @@ func (c *restoreCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	c.restorer = restorer
-	c.ui = NewUserInteractions(ctx, c.readOneChar)
 
 	// Pre-checks
 	if err := c.runPreChecks(); err != nil {
 		return errors.Trace(err)
 	}
 	// Actual restorations
+	if err := c.restoration(); err != nil {
+		return errors.Trace(err)
+	}
 	// Post-checks
-
+	if err := c.runPostChecks(); err != nil {
+		return errors.Trace(err)
+	}
 	return nil
 }
 
@@ -157,7 +169,7 @@ func (c *restoreCommand) runPreChecks() error {
 			if !c.manualAgentControl {
 				c.ui.Notify("\n\nChecking connectivity to secondary controller machines...\n")
 				connections := c.restorer.CheckSecondaryControllerNodes()
-				c.ui.Notify(populate(nodeConnectivityTemplate, connections))
+				c.ui.Notify(populate(nodesTemplate, connections))
 				for _, e := range connections {
 					if e != nil {
 						// If even one connection failed, we cannot proceed.
@@ -173,6 +185,42 @@ func (c *restoreCommand) runPreChecks() error {
 	c.ui.Notify(preChecksCompleted)
 	if err := c.ui.UserConfirmYes(); err != nil {
 		return errors.Annotate(err, "restore operation")
+	}
+	return nil
+}
+
+func (c *restoreCommand) restoration() error {
+	// Stop juju agents.
+	c.ui.Notify("\nStopping Juju agents...\n")
+	if err := c.manipulateAgents(c.restorer.StopAgents); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (c *restoreCommand) runPostChecks() error {
+	if !c.restart {
+		return nil
+	}
+	c.ui.Notify("\nStarting Juju agents...\n")
+	if err := c.manipulateAgents(c.restorer.StartAgents); err != nil {
+		return errors.Trace(err)
+	}
+
+	if c.restorer.IsHA() {
+		c.ui.Notify("Primary node may have shifted.\n")
+	}
+	return nil
+}
+
+func (c *restoreCommand) manipulateAgents(operation func(bool) map[string]error) error {
+	connections := operation(!c.manualAgentControl)
+	c.ui.Notify(populate(nodesTemplate, connections))
+	for _, e := range connections {
+		if e != nil {
+			// If even one connection failed, we cannot proceed.
+			return errors.Errorf("'juju-restore' could not manipulate all necessary agents: controllers' agents cannot be managed")
+		}
 	}
 	return nil
 }

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -136,8 +136,8 @@ func (c *restoreCommand) Run(ctx *cmd.Context) error {
 	if err := c.runPreChecks(); err != nil {
 		return errors.Trace(err)
 	}
-	// Actual restorations
-	if err := c.restoration(); err != nil {
+	// Actual restore
+	if err := c.restore(); err != nil {
 		return errors.Trace(err)
 	}
 	// Post-checks
@@ -189,7 +189,7 @@ func (c *restoreCommand) runPreChecks() error {
 	return nil
 }
 
-func (c *restoreCommand) restoration() error {
+func (c *restoreCommand) restore() error {
 	// Stop juju agents.
 	c.ui.Notify("\nStopping Juju agents...\n")
 	if err := c.manipulateAgents(c.restorer.StopAgents); err != nil {

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -7,14 +7,13 @@ import (
 	corecmd "github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
-	"github.com/juju/testing"
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/juju-restore/cmd"
 	"github.com/juju/juju-restore/core"
 	"github.com/juju/juju-restore/db"
 	"github.com/juju/juju-restore/machine"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 )
 
 type restoreSuite struct {
@@ -36,11 +35,12 @@ func (s *restoreSuite) SetUpTest(c *gc.C) {
 			return core.ReplicaSet{
 				Members: []core.ReplicaSetMember{
 					{
-						Healthy: true,
-						ID:      1,
-						Name:    "one-node",
-						State:   "PRIMARY",
-						Self:    true,
+						Healthy:       true,
+						ID:            1,
+						Name:          "one-node",
+						State:         "PRIMARY",
+						Self:          true,
+						JujuMachineID: "2",
 					},
 				},
 			}, nil
@@ -94,6 +94,7 @@ func (s *restoreSuite) TestRestoreAborted(c *gc.C) {
 	s.database.CheckCallNames(c, "ReplicaSet", "Close")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+Connecting to database...
 Checking database and replica set health...
 
 Replica set is healthy     ✓
@@ -110,12 +111,17 @@ Are you sure you want to proceed? (y/N): `[1:])
 }
 
 func (s *restoreSuite) TestRestoreProceed(c *gc.C) {
+	s.converter = func(member core.ReplicaSetMember) core.ControllerNode {
+		node := &fakeControllerNode{Stub: &testing.Stub{}, ip: member.Name}
+		return node
+	}
 	ctx, err := s.runCmd(c, "y", "backup.file")
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.database.CheckCallNames(c, "ReplicaSet", "Close")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+Connecting to database...
 Checking database and replica set health...
 
 Replica set is healthy     ✓
@@ -128,7 +134,11 @@ All restore pre-checks are completed.
 
 Restore cannot be cleanly aborted from here on.
 
-Are you sure you want to proceed? (y/N): `[1:])
+Are you sure you want to proceed? (y/N): 
+Stopping Juju agents...
+ 
+    one-node ✓ 
+`[1:])
 }
 
 func (s *restoreSuite) setupHA() {
@@ -136,17 +146,19 @@ func (s *restoreSuite) setupHA() {
 		return core.ReplicaSet{
 			Members: []core.ReplicaSetMember{
 				{
-					Healthy: true,
-					ID:      1,
-					Name:    "one:node",
-					State:   "PRIMARY",
-					Self:    true,
+					Healthy:       true,
+					ID:            1,
+					Name:          "one:node",
+					State:         "PRIMARY",
+					Self:          true,
+					JujuMachineID: "2",
 				},
 				{
-					Healthy: true,
-					ID:      2,
-					Name:    "two:node",
-					State:   "SECONDARY",
+					Healthy:       true,
+					ID:            2,
+					Name:          "two:node",
+					State:         "SECONDARY",
+					JujuMachineID: "1",
 				},
 			},
 		}, nil
@@ -166,6 +178,7 @@ func (s *restoreSuite) TestRestoreHAConnectionFail(c *gc.C) {
 	s.database.CheckCallNames(c, "ReplicaSet", "Close")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+Connecting to database...
 Checking database and replica set health...
 
 Replica set is healthy     ✓
@@ -199,6 +212,7 @@ func (s *restoreSuite) TestRestoreHAConnectionOk(c *gc.C) {
 	s.database.CheckCallNames(c, "ReplicaSet", "Close")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+Connecting to database...
 Checking database and replica set health...
 
 Replica set is healthy     ✓
@@ -234,6 +248,7 @@ func (s *restoreSuite) TestRestoreHAChoseManual(c *gc.C) {
 	s.database.CheckCallNames(c, "ReplicaSet", "Close")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+Connecting to database...
 Checking database and replica set health...
 
 Replica set is healthy     ✓
@@ -258,12 +273,16 @@ Are you sure you want to proceed? (y/N): `[1:])
 
 func (s *restoreSuite) TestRestoreHAManualControlOption(c *gc.C) {
 	s.setupHA()
+	s.converter = func(member core.ReplicaSetMember) core.ControllerNode {
+		node := &fakeControllerNode{Stub: &testing.Stub{}, ip: member.Name}
+		return node
+	}
 	ctx, err := s.runCmd(c, "y\r\ny\r\n", "backup.file", "--manual-agent-control")
 	c.Assert(err, jc.ErrorIsNil)
-
 	s.database.CheckCallNames(c, "ReplicaSet", "Close")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+Connecting to database...
 Checking database and replica set health...
 
 Replica set is healthy     ✓
@@ -272,16 +291,141 @@ Running on primary HA node ✓
 You are about to restore a controller from a backup file taken on 0001-01-01 00:00:00 +0000 UTC. 
 It contains a controller  at Juju version 0.0.0 with 0 models.
 
-Juju agents and mongo agents on secondary controller machines must be stopped by this point.
+Juju agents on secondary controller machines must be stopped by this point.
 To stop the agents, login into each secondary controller and run:
     $ systemctl stop jujud-machine-*
-    $ systemctl stop juju-db
 
 All restore pre-checks are completed.
 
 Restore cannot be cleanly aborted from here on.
 
-Are you sure you want to proceed? (y/N): `[1:])
+Are you sure you want to proceed? (y/N): 
+Stopping Juju agents...
+ 
+    one:node ✓ 
+`[1:])
+}
+
+func (s *restoreSuite) TestRestoreAgentStopFail(c *gc.C) {
+	s.setupHA()
+	s.converter = func(member core.ReplicaSetMember) core.ControllerNode {
+		node := &fakeControllerNode{Stub: &testing.Stub{}, ip: member.Name}
+		node.SetErrors(errors.New("kaboom"))
+		return node
+	}
+	ctx, err := s.runCmd(c, "y\r\ny\r\n", "backup.file", "--manual-agent-control")
+	c.Assert(err, gc.ErrorMatches, "'juju-restore' could not manipulate all necessary agents: controllers' agents cannot be managed")
+	s.database.CheckCallNames(c, "ReplicaSet", "Close")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+Connecting to database...
+Checking database and replica set health...
+
+Replica set is healthy     ✓
+Running on primary HA node ✓
+
+You are about to restore a controller from a backup file taken on 0001-01-01 00:00:00 +0000 UTC. 
+It contains a controller  at Juju version 0.0.0 with 0 models.
+
+Juju agents on secondary controller machines must be stopped by this point.
+To stop the agents, login into each secondary controller and run:
+    $ systemctl stop jujud-machine-*
+
+All restore pre-checks are completed.
+
+Restore cannot be cleanly aborted from here on.
+
+Are you sure you want to proceed? (y/N): 
+Stopping Juju agents...
+ 
+    one:node ✗ error: kaboom
+`[1:])
+}
+
+func (s *restoreSuite) TestRestoreStartAgents(c *gc.C) {
+	s.converter = func(member core.ReplicaSetMember) core.ControllerNode {
+		node := &fakeControllerNode{Stub: &testing.Stub{}, ip: member.Name}
+		return node
+	}
+	ctx, err := s.runCmd(c, "y", "backup.file", "--rs")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.database.CheckCallNames(c, "ReplicaSet", "ReplicaSet", "Close")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+Connecting to database...
+Checking database and replica set health...
+
+Replica set is healthy     ✓
+Running on primary HA node ✓
+
+You are about to restore a controller from a backup file taken on 0001-01-01 00:00:00 +0000 UTC. 
+It contains a controller  at Juju version 0.0.0 with 0 models.
+
+All restore pre-checks are completed.
+
+Restore cannot be cleanly aborted from here on.
+
+Are you sure you want to proceed? (y/N): 
+Stopping Juju agents...
+ 
+    one-node ✓ 
+
+Starting Juju agents...
+ 
+    one-node ✓ 
+`[1:])
+}
+
+func (s *restoreSuite) TestRestoreStartAgentsInHA(c *gc.C) {
+	s.setupHA()
+	s.converter = func(member core.ReplicaSetMember) core.ControllerNode {
+		node := &fakeControllerNode{Stub: &testing.Stub{}, ip: member.Name}
+		return node
+	}
+	ctx, err := s.runCmd(c, "yy", "backup.file", "--rs")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.database.CheckCallNames(c, "ReplicaSet", "ReplicaSet", "Close")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+Connecting to database...
+Checking database and replica set health...
+
+Replica set is healthy     ✓
+Running on primary HA node ✓
+
+You are about to restore a controller from a backup file taken on 0001-01-01 00:00:00 +0000 UTC. 
+It contains a controller  at Juju version 0.0.0 with 0 models.
+
+This controller is in HA and to restore into it successfully, 
+'juju-restore' needs to manage Juju and Mongo agents on  
+secondary controller nodes.
+However, on the bigger systems, the operator might want to manage 
+these agents manually.
+
+Do you want 'juju-restore' to manage these agents automatically? (y/N): 
+
+Checking connectivity to secondary controller machines...
+ 
+    two:node ✓ 
+
+All restore pre-checks are completed.
+
+Restore cannot be cleanly aborted from here on.
+
+Are you sure you want to proceed? (y/N): 
+Stopping Juju agents...
+ 
+    one:node ✓  
+    two:node ✓ 
+
+Starting Juju agents...
+ 
+    one:node ✓  
+    two:node ✓ 
+Primary node may have shifted.
+`[1:])
 }
 
 func (s *restoreSuite) runCmd(c *gc.C, input string, args ...string) (*corecmd.Context, error) {
@@ -325,5 +469,15 @@ func (f *fakeControllerNode) IP() string {
 
 func (f *fakeControllerNode) Ping() error {
 	f.Stub.MethodCall(f, "Ping")
+	return f.NextErr()
+}
+
+func (f *fakeControllerNode) StopAgent() error {
+	f.Stub.MethodCall(f, "StopAgent")
+	return f.NextErr()
+}
+
+func (f *fakeControllerNode) StartAgent() error {
+	f.Stub.MethodCall(f, "StartAgent")
 	return f.NextErr()
 }

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -7,13 +7,14 @@ import (
 	corecmd "github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
 	"github.com/juju/juju-restore/cmd"
 	"github.com/juju/juju-restore/core"
 	"github.com/juju/juju-restore/db"
 	"github.com/juju/juju-restore/machine"
-	"github.com/juju/testing"
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
 )
 
 type restoreSuite struct {

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -52,6 +52,16 @@ type ReplicaSetMember struct {
 	// with the replica set it could be any one of the values listed
 	// at https://docs.mongodb.com/manual/reference/replica-states/
 	State string
+
+	// JujuMachineID has Juju machine ID for this controller node.
+	// This information is needed when trying to manage Juju agents,
+	// their config or any other artifacts created by Juju.
+	JujuMachineID string
+}
+
+// String is part of Stringer.
+func (m ReplicaSetMember) String() string {
+	return fmt.Sprintf("%d %q (juju machine %v)", m.ID, m.Name, m.JujuMachineID)
 }
 
 // ControllerNode defines behavior for a controller node machine.
@@ -61,11 +71,12 @@ type ControllerNode interface {
 
 	// Ping checks connection to the controller machine.
 	Ping() error
-}
 
-// String is part of Stringer.
-func (m ReplicaSetMember) String() string {
-	return fmt.Sprintf("%d %q", m.ID, m.Name)
+	// StopAgent stops jujud-machine-* service on the controller node.
+	StopAgent() error
+
+	// StartAgent starts jujud-machine-* service on the controller node.
+	StartAgent() error
 }
 
 // PrecheckResult contains the results of a pre-check run.

--- a/core/restorer.go
+++ b/core/restorer.go
@@ -6,9 +6,9 @@ package core
 import (
 	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/utils/clock"
 	"github.com/kr/pretty"
 	"gopkg.in/retry.v1"
 )

--- a/core/restorer_test.go
+++ b/core/restorer_test.go
@@ -4,10 +4,8 @@
 package core_test
 
 import (
-	"fmt"
 	"regexp"
 
-	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -451,12 +449,4 @@ func (f *fakeControllerNode) StopAgent() error {
 func (f *fakeControllerNode) StartAgent() error {
 	f.Stub.MethodCall(f, "StartAgent")
 	return f.NextErr()
-}
-
-type fakeFeedback struct {
-	out *cmd.Context
-}
-
-func (f *fakeFeedback) Notify(message string) {
-	fmt.Fprintf(f.out.Stdout, message)
 }

--- a/core/restorer_test.go
+++ b/core/restorer_test.go
@@ -5,12 +5,13 @@ package core_test
 
 import (
 	"fmt"
+	"regexp"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"regexp"
 
 	"github.com/juju/juju-restore/core"
 	"github.com/juju/juju-restore/machine"

--- a/core/restorer_test.go
+++ b/core/restorer_test.go
@@ -4,10 +4,13 @@
 package core_test
 
 import (
+	"fmt"
+	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"regexp"
 
 	"github.com/juju/juju-restore/core"
 	"github.com/juju/juju-restore/machine"
@@ -30,20 +33,23 @@ func (s *restorerSuite) TestCheckDatabaseStateUnhealthyMembers(c *gc.C) {
 		replicaSetF: func() (core.ReplicaSet, error) {
 			return core.ReplicaSet{
 				Members: []core.ReplicaSetMember{{
-					Healthy: false,
-					ID:      1,
-					Name:    "kaira-ba",
-					State:   "SECONDARY",
+					Healthy:       false,
+					ID:            1,
+					Name:          "kaira-ba",
+					State:         "SECONDARY",
+					JujuMachineID: "0",
 				}, {
-					Healthy: true,
-					ID:      2,
-					Name:    "djula",
-					State:   "PRIMARY",
+					Healthy:       true,
+					ID:            2,
+					Name:          "djula",
+					State:         "PRIMARY",
+					JujuMachineID: "1",
 				}, {
-					Healthy: true,
-					ID:      3,
-					Name:    "bibi",
-					State:   "OUCHY",
+					Healthy:       true,
+					ID:            3,
+					Name:          "bibi",
+					State:         "OUCHY",
+					JujuMachineID: "2",
 				}},
 			}, nil
 		},
@@ -51,7 +57,7 @@ func (s *restorerSuite) TestCheckDatabaseStateUnhealthyMembers(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = r.CheckDatabaseState()
 	c.Assert(err, jc.Satisfies, core.IsUnhealthyMembersError)
-	c.Assert(err, gc.ErrorMatches, `unhealthy replica set members: 1 "kaira-ba", 3 "bibi"`)
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`unhealthy replica set members: 1 "kaira-ba" (juju machine 0), 3 "bibi" (juju machine 2)`))
 }
 
 func (s *restorerSuite) TestCheckDatabaseStateNoPrimary(c *gc.C) {
@@ -59,20 +65,23 @@ func (s *restorerSuite) TestCheckDatabaseStateNoPrimary(c *gc.C) {
 		replicaSetF: func() (core.ReplicaSet, error) {
 			return core.ReplicaSet{
 				Members: []core.ReplicaSetMember{{
-					Healthy: true,
-					ID:      1,
-					Name:    "kaira-ba",
-					State:   "SECONDARY",
+					Healthy:       true,
+					ID:            1,
+					Name:          "kaira-ba",
+					State:         "SECONDARY",
+					JujuMachineID: "2",
 				}, {
-					Healthy: true,
-					ID:      2,
-					Name:    "djula",
-					State:   "SECONDARY",
+					Healthy:       true,
+					ID:            2,
+					Name:          "djula",
+					State:         "SECONDARY",
+					JujuMachineID: "1",
 				}, {
-					Healthy: true,
-					ID:      3,
-					Name:    "bibi",
-					State:   "SECONDARY",
+					Healthy:       true,
+					ID:            3,
+					Name:          "bibi",
+					State:         "SECONDARY",
+					JujuMachineID: "0",
 				}},
 			}, nil
 		},
@@ -87,28 +96,31 @@ func (s *restorerSuite) TestCheckDatabaseStateNotPrimary(c *gc.C) {
 		replicaSetF: func() (core.ReplicaSet, error) {
 			return core.ReplicaSet{
 				Members: []core.ReplicaSetMember{{
-					Healthy: true,
-					ID:      1,
-					Name:    "kaira-ba",
-					State:   "SECONDARY",
-					Self:    true,
+					Healthy:       true,
+					ID:            1,
+					Name:          "kaira-ba",
+					State:         "SECONDARY",
+					Self:          true,
+					JujuMachineID: "1",
 				}, {
-					Healthy: true,
-					ID:      2,
-					Name:    "djula",
-					State:   "PRIMARY",
+					Healthy:       true,
+					ID:            2,
+					Name:          "djula",
+					State:         "PRIMARY",
+					JujuMachineID: "2",
 				}, {
-					Healthy: true,
-					ID:      3,
-					Name:    "bibi",
-					State:   "SECONDARY",
+					Healthy:       true,
+					ID:            3,
+					Name:          "bibi",
+					State:         "SECONDARY",
+					JujuMachineID: "0",
 				}},
 			}, nil
 		},
 	}, s.converter)
 	c.Assert(err, jc.ErrorIsNil)
 	err = r.CheckDatabaseState()
-	c.Assert(err, gc.ErrorMatches, `not running on primary replica set member, primary is 2 "djula"`)
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`not running on primary replica set member, primary is 2 "djula" (juju machine 2)`))
 }
 
 func (s *restorerSuite) TestCheckDatabaseStateAllGood(c *gc.C) {
@@ -116,21 +128,24 @@ func (s *restorerSuite) TestCheckDatabaseStateAllGood(c *gc.C) {
 		replicaSetF: func() (core.ReplicaSet, error) {
 			return core.ReplicaSet{
 				Members: []core.ReplicaSetMember{{
-					Healthy: true,
-					ID:      1,
-					Name:    "kaira-ba",
-					State:   "SECONDARY",
+					Healthy:       true,
+					ID:            1,
+					Name:          "kaira-ba",
+					State:         "SECONDARY",
+					JujuMachineID: "0",
 				}, {
-					Healthy: true,
-					ID:      2,
-					Name:    "djula",
-					State:   "PRIMARY",
-					Self:    true,
+					Healthy:       true,
+					ID:            2,
+					Name:          "djula",
+					State:         "PRIMARY",
+					Self:          true,
+					JujuMachineID: "1",
 				}, {
-					Healthy: true,
-					ID:      3,
-					Name:    "bibi",
-					State:   "SECONDARY",
+					Healthy:       true,
+					ID:            3,
+					Name:          "bibi",
+					State:         "SECONDARY",
+					JujuMachineID: "2",
 				}},
 			}, nil
 		},
@@ -146,6 +161,27 @@ func (s *restorerSuite) TestCheckDatabaseStateOneMember(c *gc.C) {
 		replicaSetF: func() (core.ReplicaSet, error) {
 			return core.ReplicaSet{
 				Members: []core.ReplicaSetMember{{
+					Healthy:       true,
+					ID:            2,
+					Name:          "djula",
+					State:         "PRIMARY",
+					Self:          true,
+					JujuMachineID: "2",
+				}},
+			}, nil
+		},
+	}, s.converter)
+	c.Assert(err, jc.ErrorIsNil)
+	err = r.CheckDatabaseState()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r.IsHA(), jc.IsFalse)
+}
+
+func (s *restorerSuite) TestCheckDatabaseStateMissingJujuID(c *gc.C) {
+	r, err := core.NewRestorer(&fakeDatabase{
+		replicaSetF: func() (core.ReplicaSet, error) {
+			return core.ReplicaSet{
+				Members: []core.ReplicaSetMember{{
 					Healthy: true,
 					ID:      2,
 					Name:    "djula",
@@ -157,8 +193,7 @@ func (s *restorerSuite) TestCheckDatabaseStateOneMember(c *gc.C) {
 	}, s.converter)
 	c.Assert(err, jc.ErrorIsNil)
 	err = r.CheckDatabaseState()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(r.IsHA(), jc.IsFalse)
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`unhealthy replica set members: 2 "djula" (juju machine )`))
 }
 
 func (s *restorerSuite) TestCheckSecondaryControllerNodesSkipsSelf(c *gc.C) {
@@ -167,11 +202,12 @@ func (s *restorerSuite) TestCheckSecondaryControllerNodesSkipsSelf(c *gc.C) {
 			return core.ReplicaSet{
 				Members: []core.ReplicaSetMember{
 					{
-						Healthy: true,
-						ID:      2,
-						Name:    "djula:wot",
-						State:   "PRIMARY",
-						Self:    true,
+						Healthy:       true,
+						ID:            2,
+						Name:          "djula:wot",
+						State:         "PRIMARY",
+						Self:          true,
+						JujuMachineID: "2",
 					},
 				},
 			}, nil
@@ -187,17 +223,19 @@ func (s *restorerSuite) checkSecondaryControllerNodes(c *gc.C, expected map[stri
 			return core.ReplicaSet{
 				Members: []core.ReplicaSetMember{
 					{
-						Healthy: true,
-						ID:      2,
-						Name:    "djula",
-						State:   "PRIMARY",
-						Self:    true,
+						Healthy:       true,
+						ID:            2,
+						Name:          "djula",
+						State:         "PRIMARY",
+						Self:          true,
+						JujuMachineID: "2",
 					},
 					{
-						Healthy: true,
-						ID:      1,
-						Name:    "wot",
-						State:   "SECONDARY",
+						Healthy:       true,
+						ID:            1,
+						Name:          "wot",
+						State:         "SECONDARY",
+						JujuMachineID: "1",
 					},
 				},
 			}, nil
@@ -222,6 +260,157 @@ func (s *restorerSuite) TestCheckSecondaryControllerNodesFail(c *gc.C) {
 		return node
 	}
 	s.checkSecondaryControllerNodes(c, map[string]error{"wot": err})
+}
+
+type agentMgmtTest struct {
+	mgmtFunc    func(*core.Restorer, bool) map[string]error
+	secondaries bool
+	result      map[string]error
+	nodeErrs    map[string]string
+}
+
+func (s *restorerSuite) checkManagedAgents(c *gc.C, t agentMgmtTest) []*fakeControllerNode {
+	nodes := []*fakeControllerNode{}
+	s.converter = func(member core.ReplicaSetMember) core.ControllerNode {
+		node := &fakeControllerNode{Stub: &testing.Stub{}, ip: member.Name}
+		nodes = append(nodes, node)
+		if e := t.nodeErrs[member.Name]; e != "" {
+			node.SetErrors(errors.New(e))
+		}
+		return node
+	}
+
+	r, err := core.NewRestorer(&fakeDatabase{
+		replicaSetF: func() (core.ReplicaSet, error) {
+			return core.ReplicaSet{
+				Members: []core.ReplicaSetMember{
+					{
+						Healthy:       true,
+						ID:            2,
+						Name:          "djula",
+						State:         "PRIMARY",
+						Self:          true,
+						JujuMachineID: "2",
+					},
+					{
+						Healthy:       true,
+						ID:            1,
+						Name:          "wot",
+						State:         "SECONDARY",
+						JujuMachineID: "1",
+					},
+				},
+			}, nil
+		},
+	}, s.converter)
+	c.Assert(err, jc.ErrorIsNil)
+
+	result := t.mgmtFunc(r, t.secondaries)
+	c.Assert(len(result), gc.Equals, len(t.result))
+	for k, v := range result {
+		if v != nil {
+			c.Assert(v, gc.ErrorMatches, t.result[k].Error())
+		} else {
+			c.Assert(v, jc.ErrorIsNil)
+		}
+	}
+	return nodes
+}
+
+func (s *restorerSuite) TestStopAgentsWithSecondaries(c *gc.C) {
+	nodes := s.checkManagedAgents(c, agentMgmtTest{
+		func(r *core.Restorer, s bool) map[string]error { return r.StopAgents(s) },
+		true,
+		map[string]error{
+			"wot":   nil,
+			"djula": nil,
+		},
+		map[string]string{},
+	})
+	c.Assert(nodes, gc.HasLen, 2)
+	for _, n := range nodes {
+		n.CheckCallNames(c, "IP", "StopAgent")
+	}
+}
+
+func (s *restorerSuite) TestStopAgentsNoSecondaries(c *gc.C) {
+	nodes := s.checkManagedAgents(c, agentMgmtTest{
+		func(r *core.Restorer, s bool) map[string]error { return r.StopAgents(s) },
+		false,
+		map[string]error{
+			"djula": nil,
+		},
+		map[string]string{},
+	})
+	c.Assert(nodes, gc.HasLen, 2)
+	for _, n := range nodes {
+		// When no secondaries are requested, only primary node will be run
+		if n.IP() == "djula" {
+			n.CheckCallNames(c, "IP", "StopAgent", "IP")
+		} else {
+			n.CheckCallNames(c, "IP")
+		}
+	}
+}
+
+func (s *restorerSuite) TestStopAgentFail(c *gc.C) {
+	s.checkManagedAgents(c, agentMgmtTest{
+		func(r *core.Restorer, s bool) map[string]error { return r.StopAgents(s) },
+		true,
+		map[string]error{
+			"djula": errors.New("kaboom"),
+			"wot":   nil,
+		},
+		map[string]string{"djula": "kaboom"},
+	})
+}
+
+func (s *restorerSuite) TestStartAgentsWithSecondaries(c *gc.C) {
+	nodes := s.checkManagedAgents(c, agentMgmtTest{
+		func(r *core.Restorer, s bool) map[string]error { return r.StartAgents(s) },
+		true,
+		map[string]error{
+			"wot":   nil,
+			"djula": nil,
+		},
+		map[string]string{},
+	})
+	c.Assert(nodes, gc.HasLen, 2)
+	for _, n := range nodes {
+		n.CheckCallNames(c, "IP", "StartAgent")
+	}
+}
+
+func (s *restorerSuite) TestStartAgentsNoSecondaries(c *gc.C) {
+	nodes := s.checkManagedAgents(c, agentMgmtTest{
+		func(r *core.Restorer, s bool) map[string]error { return r.StartAgents(s) },
+		false,
+		map[string]error{
+			"djula": nil,
+		},
+		map[string]string{},
+	})
+	c.Assert(nodes, gc.HasLen, 2)
+	for _, n := range nodes {
+		// When no secondaries are requested, only primary node will be run
+		if n.IP() == "djula" {
+			n.CheckCallNames(c, "IP", "StartAgent", "IP")
+		} else {
+			n.CheckCallNames(c, "IP")
+		}
+	}
+}
+
+func (s *restorerSuite) TestStartAgentFail(c *gc.C) {
+	s.checkManagedAgents(c, agentMgmtTest{
+		func(r *core.Restorer, s bool) map[string]error { return r.StartAgents(s) },
+		true,
+		map[string]error{
+			"wot":   errors.New("kaboom"),
+			"djula": nil,
+		},
+		map[string]string{"wot": "kaboom"},
+	})
 }
 
 type fakeDatabase struct {
@@ -251,4 +440,22 @@ func (f *fakeControllerNode) IP() string {
 func (f *fakeControllerNode) Ping() error {
 	f.Stub.MethodCall(f, "Ping")
 	return f.NextErr()
+}
+
+func (f *fakeControllerNode) StopAgent() error {
+	f.Stub.MethodCall(f, "StopAgent")
+	return f.NextErr()
+}
+
+func (f *fakeControllerNode) StartAgent() error {
+	f.Stub.MethodCall(f, "StartAgent")
+	return f.NextErr()
+}
+
+type fakeFeedback struct {
+	out *cmd.Context
+}
+
+func (f *fakeFeedback) Notify(message string) {
+	fmt.Fprintf(f.out.Stdout, message)
 }

--- a/machine/commandrunner.go
+++ b/machine/commandrunner.go
@@ -1,0 +1,70 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+
+	"github.com/juju/errors"
+)
+
+// CommandRunner defines what is needed to run a command on a machine.
+type CommandRunner interface {
+	// All strings within the command must be individually passed-in.
+	// For example,
+	//     to run 'echo hi:D', pass in "echo", "hi:D",
+	//     to stop juju-db, pass in "systemctl", "stop", "juju-db".
+	Run(commands ...string) (string, error)
+}
+
+type localRunner struct{}
+
+// NewLocalRunner constructs a command runner that runs commands locally.
+func NewLocalRunner() CommandRunner {
+	return &localRunner{}
+}
+
+// Run implements CommandRunner.Run.
+func (r *localRunner) Run(commands ...string) (string, error) {
+	// Since we are logged in as a 'ubuntu' user,
+	// we need to run in sudo to switch to 'root' user to elevate privileges.
+	customSSH := exec.Command(commands[0], commands[1:]...)
+	var out bytes.Buffer
+	customSSH.Stdout = &out
+	cmdErr := bytes.Buffer{}
+	customSSH.Stderr = &cmdErr
+	if err := customSSH.Run(); err != nil {
+		if cmdErr.Len() > 0 {
+			return "", errors.New(cmdErr.String())
+		}
+		return "", err
+	}
+	return out.String(), nil
+}
+
+type remoteRunner struct {
+	*localRunner
+	ip string
+}
+
+// NewRemoteRunner constructs a command runner that runs commands remotely using ssh.
+func NewRemoteRunner(ip string) CommandRunner {
+	return &remoteRunner{&localRunner{}, ip}
+}
+
+// Run implements CommandRunner.Run.
+func (r *remoteRunner) Run(commands ...string) (string, error) {
+	args := []string{
+		"sudo",
+		"ssh",
+		"-o", "StrictHostKeyChecking no",
+		"-t", "-t", // twice to force tty allocation, even if ssh jas no local tty
+		"-i", "/var/lib/juju/system-identity", // only root can read /var/lib/juju/system-identity
+		fmt.Sprintf("ubuntu@%v", r.ip),
+	}
+	args = append(args, commands...)
+	return r.localRunner.Run(args...)
+}

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -10,24 +10,30 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 
 	"github.com/juju/juju-restore/core"
 )
+
+var logger = loggo.GetLogger("juju-restore.machine")
 
 // ControllerNodeForReplicaSetMember returns ControllerNode for ReplicaSetMember.
 func ControllerNodeForReplicaSetMember(member core.ReplicaSetMember) core.ControllerNode {
 	//	Replica set member name is in the form <machine IP>:<Mongo port>.
 	ip := member.Name[:strings.Index(member.Name, ":")]
-	return New(ip)
+	return New(ip, member.JujuMachineID, member.Self)
 }
 
 type Machine struct {
 	ip string
+
+	jujuID string
+	self   bool
 }
 
 // New returns a machine that satisfies core.ControllerNode.
-func New(ip string) *Machine {
-	return &Machine{ip}
+func New(ip string, jujuID string, self bool) *Machine {
+	return &Machine{ip, jujuID, self}
 }
 
 // IP implements ControllerNode.IP.
@@ -39,6 +45,10 @@ func (r *Machine) IP() string {
 // by ssh'ing into the machine and executing an 'echo' command.
 func (r *Machine) Ping() error {
 	command := fmt.Sprintf("hello from %v", r.IP())
+	if r.self {
+		logger.Debugf("%v, self", command)
+		return nil
+	}
 	out, err := runRemoteCommand(r, "echo", command)
 	if err != nil {
 		return err
@@ -51,6 +61,44 @@ func (r *Machine) Ping() error {
 	return nil
 }
 
+// StopAgent implements ControllerNode.StopAgent.
+func (r *Machine) StopAgent() error {
+	command := []string{"sudo", "systemctl", "stop", fmt.Sprintf("jujud-machine-%v", r.jujuID)}
+	var out string
+	var err error
+	if r.self {
+		out, err = runCommand(command...)
+	} else {
+		out, err = runRemoteCommand(r, command...)
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if out != "" {
+		return errors.Errorf("stop agent command should not have returned any output, but got %v", out)
+	}
+	return nil
+}
+
+// StartAgent implements ControllerNode.StartAgent.
+func (r *Machine) StartAgent() error {
+	command := []string{"sudo", "systemctl", "start", fmt.Sprintf("jujud-machine-%v", r.jujuID)}
+	var out string
+	var err error
+	if r.self {
+		out, err = runCommand(command...)
+	} else {
+		out, err = runRemoteCommand(r, command...)
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if out != "" {
+		return errors.Errorf("start agent command should not have returned any output, but got %v", out)
+	}
+	return nil
+}
+
 // runRemoteCommand takes in a command and runs it remotely using ssh.
 // All strings within the command must be individually passed-in.
 // For example,
@@ -58,17 +106,23 @@ func (r *Machine) Ping() error {
 //     to stop juju-db, pass in "systemctl", "stop", "juju-db".
 var runRemoteCommand = func(r *Machine, commands ...string) (string, error) {
 	args := []string{
+		"sudo",
 		"ssh",
 		"-o", "StrictHostKeyChecking no",
 		"-t", "-t", // twice to force tty allocation, even if ssh jas no local tty
-		"-i", "/var/lib/juju/system-identity",
+		"-i", "/var/lib/juju/system-identity", // only root can read /var/lib/juju/system-identity
 		fmt.Sprintf("ubuntu@%v", r.IP()),
 	}
 	args = append(args, commands...)
-	// Since we are on the primary controller node, logged in as a 'ubuntu' user,
-	// we need to run in sudo to switch to 'root' user to elevate privileges
-	// since only root can read /var/lib/juju/system-identity.
-	customSSH := exec.Command("sudo", args...)
+	return runCommand(args...)
+}
+
+// runCommand runs a command.
+// All strings within the command must be individually passed-in.
+var runCommand = func(commands ...string) (string, error) {
+	// Since we are logged in as a 'ubuntu' user,
+	// we need to run in sudo to switch to 'root' user to elevate privileges.
+	customSSH := exec.Command(commands[0], commands[1:]...)
 	var out bytes.Buffer
 	customSSH.Stdout = &out
 	cmdErr := bytes.Buffer{}


### PR DESCRIPTION
## Description of change

As part of the Level 0 pre-check, we need to bring down Juju agents on primary controller node as well as on the secondary controller nodes if they are managed by 'juju-restore' and not the user.

Since we will eventually need to start these stopped agents up, the PR also allows to restart the agents if --rs option is provided. This option will be removed once the actual restore will be implemented since it will be a normal flow of operation - stop agents, restore, start agents again.
 
To correctly name juju agent (juud-machine-*), we need to know Juju Machine ID. This PR also adds this information to replica set member.


## QA steps

1. bootstrap
2. enable-ha
3. run 'juju-restore' on a primary
4. Once the prompts are answered, all juju agents should be stopped. I checked with 'systemctl status jujud-machine-*' on each controller machine.
5. If desired, re-run 'juju-restore' with --rs to restart Juju agents.

