### PR TITLE
Extract controller details and check them against backup metadata

### DIFF
--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -40,7 +40,7 @@ Do you want 'juju-restore' to manage these agents automatically? (y/N): `
 
 	backupFileTemplate = `
 You are about to restore a controller from a backup file taken on {{.BackupDate}}. 
-It contains a controller {{.ControllerUUID}} at Juju version {{.JujuVersion}} with {{.ModelCount}} models.
+It contains a controller {{.ControllerModelUUID}} at Juju version {{.JujuVersion}} with {{.ModelCount}} models.
 `
 
 	preChecksCompleted = `

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -165,8 +165,12 @@ func (c *restoreCommand) runPreChecks() error {
 	}
 	c.ui.Notify(dbHealthComplete)
 
-	// TODO Backup file checks go here?
-	c.ui.Notify(populate(backupFileTemplate, &core.PrecheckResult{}))
+	precheckResult, err := c.restorer.CheckRestorable()
+	if err != nil {
+		return errors.Annotate(err, "precheck")
+	}
+
+	c.ui.Notify(populate(backupFileTemplate, precheckResult))
 
 	if c.restorer.IsHA() {
 		if !c.manualAgentControl {

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -450,12 +450,18 @@ func (s *restoreSuite) runCmd(c *gc.C, input string, args ...string) (*corecmd.C
 
 type testDatabase struct {
 	*testing.Stub
-	replicaSetF func() (core.ReplicaSet, error)
+	replicaSetF     func() (core.ReplicaSet, error)
+	controllerInfoF func() (core.ControllerInfo, error)
 }
 
 func (d *testDatabase) ReplicaSet() (core.ReplicaSet, error) {
 	d.AddCall("ReplicaSet")
 	return d.replicaSetF()
+}
+
+func (d *testDatabase) ControllerInfo() (core.ControllerInfo, error) {
+	d.AddCall("ControllerInfo")
+	return d.controllerInfoF()
 }
 
 func (d *testDatabase) Close() {

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -105,14 +105,15 @@ type PrecheckResult struct {
 	// BackupDate is the date the backup was finished.
 	BackupDate time.Time
 
-	// ControllerUUID is the controller UUID from which backup was taken.
-	ControllerUUID string
+	// ControllerModelUUID is the controller model UUID from which
+	// backup was taken.
+	ControllerModelUUID string
 
 	// JujuVersion is the Juju version of the controller from which backup was taken.
 	JujuVersion version.Number
 
 	// ModelCount is the count of models that this backup contains.
-	ModelCount int64
+	ModelCount int
 }
 
 const (

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -16,6 +16,10 @@ type Database interface {
 	// ReplicaSet gets the status of the replica set and all members.
 	ReplicaSet() (ReplicaSet, error)
 
+	// ControllerInfo gets information about the controller that we
+	// can compare to the backup file.
+	ControllerInfo() (ControllerInfo, error)
+
 	// Close terminates the database connection.
 	Close()
 }
@@ -29,6 +33,23 @@ type ReplicaSet struct {
 
 	// Members lists the nodes that make up the set.
 	Members []ReplicaSetMember
+}
+
+// ControllerInfo holds identifying information about a Juju controller.
+type ControllerInfo struct {
+	// ControllerModelUUID is the controller model UUID for this controller.
+	ControllerModelUUID string
+
+	// JujuVersion is the version of Juju running on this controller.
+	JujuVersion version.Number
+
+	// Series is the OS series the controller is deployed on. Ths
+	// determines what version of mongo is installed and whether we
+	// can restore a given backup.
+	Series string
+
+	// HANodes is the count of controller machines.
+	HANodes int
 }
 
 // ReplicaSetMember holds status information about a database replica

--- a/core/restorer_test.go
+++ b/core/restorer_test.go
@@ -414,12 +414,18 @@ func (s *restorerSuite) TestStartAgentFail(c *gc.C) {
 
 type fakeDatabase struct {
 	testing.Stub
-	replicaSetF func() (core.ReplicaSet, error)
+	replicaSetF     func() (core.ReplicaSet, error)
+	controllerInfoF func() (core.ControllerInfo, error)
 }
 
 func (db *fakeDatabase) ReplicaSet() (core.ReplicaSet, error) {
 	db.Stub.MethodCall(db, "ReplicaSet")
 	return db.replicaSetF()
+}
+
+func (db *fakeDatabase) ControllerInfo() (core.ControllerInfo, error) {
+	db.Stub.MethodCall(db, "ControllerInfo")
+	return db.controllerInfoF()
 }
 
 func (db *fakeDatabase) Close() {

--- a/core/restorer_test.go
+++ b/core/restorer_test.go
@@ -5,10 +5,12 @@ package core_test
 
 import (
 	"regexp"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju-restore/core"
@@ -410,6 +412,116 @@ func (s *restorerSuite) TestStartAgentFail(c *gc.C) {
 		},
 		map[string]string{"wot": "kaboom"},
 	})
+}
+
+func (s *restorerSuite) TestCheckRestorable(c *gc.C) {
+	created, err := time.Parse(time.RFC3339, "2020-03-17T12:24:30Z")
+	c.Assert(err, jc.ErrorIsNil)
+	r, err := core.NewRestorer(&fakeDatabase{
+		replicaSetF: func() (core.ReplicaSet, error) {
+			return core.ReplicaSet{}, nil
+		},
+		controllerInfoF: func() (core.ControllerInfo, error) {
+			return core.ControllerInfo{
+				ControllerModelUUID: "alex the astronaut",
+				JujuVersion:         version.MustParse("2.8-beta5.6"),
+				HANodes:             5,
+				Series:              "eoan",
+			}, nil
+		},
+	}, &fakeBackup{
+		metadataF: func() (core.BackupMetadata, error) {
+			return core.BackupMetadata{
+				ControllerModelUUID: "alex the astronaut",
+				JujuVersion:         version.MustParse("2.8-beta5.3"),
+				Series:              "eoan",
+				BackupCreated:       created,
+				ModelCount:          3,
+				HANodes:             5,
+			}, nil
+		},
+	}, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := r.CheckRestorable()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(result, gc.DeepEquals, &core.PrecheckResult{
+		BackupDate:          created,
+		ControllerModelUUID: "alex the astronaut",
+		JujuVersion:         version.MustParse("2.8-beta5.3"),
+		ModelCount:          3,
+	})
+}
+
+func (s *restorerSuite) checkRestorableMismatch(c *gc.C, expectErr string, tweak func(*core.ControllerInfo)) {
+	created, err := time.Parse(time.RFC3339, "2020-03-17T12:24:30Z")
+	c.Assert(err, jc.ErrorIsNil)
+
+	controllerInfo := core.ControllerInfo{
+		ControllerModelUUID: "porridge radio",
+		JujuVersion:         version.MustParse("2.8-beta5.6"),
+		HANodes:             5,
+		Series:              "eoan",
+	}
+	tweak(&controllerInfo)
+
+	r, err := core.NewRestorer(&fakeDatabase{
+		replicaSetF: func() (core.ReplicaSet, error) {
+			return core.ReplicaSet{}, nil
+		},
+		controllerInfoF: func() (core.ControllerInfo, error) {
+			return controllerInfo, nil
+		},
+	}, &fakeBackup{
+		metadataF: func() (core.BackupMetadata, error) {
+			return core.BackupMetadata{
+				ControllerModelUUID: "porridge radio",
+				JujuVersion:         version.MustParse("2.8-beta5.3"),
+				Series:              "eoan",
+				BackupCreated:       created,
+				ModelCount:          3,
+				HANodes:             5,
+			}, nil
+		},
+	}, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := r.CheckRestorable()
+	c.Assert(err, gc.ErrorMatches, expectErr)
+	c.Assert(result, gc.IsNil)
+}
+
+func (s *restorerSuite) TestCheckRestorableMismatchController(c *gc.C) {
+	s.checkRestorableMismatch(c, `controller model uuids don't match - backup: "porridge radio", controller: "alex the astronaut"`,
+		func(i *core.ControllerInfo) {
+			i.ControllerModelUUID = "alex the astronaut"
+		},
+	)
+}
+
+func (s *restorerSuite) TestCheckRestorableMismatchJujuVersion(c *gc.C) {
+	s.checkRestorableMismatch(c, `juju versions don't match - backup: "2.8-beta5.3", controller: "2.7.5"`,
+		func(i *core.ControllerInfo) {
+			i.JujuVersion = version.MustParse("2.7.5")
+		},
+	)
+}
+
+func (s *restorerSuite) TestCheckRestorableMismatchHANodes(c *gc.C) {
+	s.checkRestorableMismatch(c, `controller HA node counts don't match - backup: 5, controller: 3`,
+		func(i *core.ControllerInfo) {
+			i.HANodes = 3
+		},
+	)
+}
+
+func (s *restorerSuite) TestCheckRestorableMismatchSeries(c *gc.C) {
+	s.checkRestorableMismatch(c, `controller series don't match - backup: "eoan", controller: "zesty"`,
+		func(i *core.ControllerInfo) {
+			i.Series = "zesty"
+		},
+	)
 }
 
 type fakeDatabase struct {

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
+github.com/frankban/quicktest v1.2.2 h1:xfmOhhoH5fGPgbEAlhLpJH9p0z/0Qizio9osmvn9IUY=
 github.com/frankban/quicktest v1.2.2/go.mod h1:Qh/WofXFeiAFII1aEBu529AtJo6Zg2VHscnEsbBnJ20=
+github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42 h1:q3pnF5JFBNRz8sRD+IRj7Y6DMyYGTNqnZ9axTbSfoNI=
 github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
@@ -12,7 +14,6 @@ github.com/juju/errors v0.0.0-20190930114154-d42613fe1ab9 h1:hJix6idebFclqlfZCHE
 github.com/juju/errors v0.0.0-20190930114154-d42613fe1ab9/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d h1:c93kUJDtVAXFEhsCh5jSxyOJmFHuzcihnslQiX8Urwo=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
-github.com/juju/juju-restore v0.0.0-20200120060349-547b19d643a3 h1:waBbWPTmS1k+p/vn9pgMRkz98FNUhFmsN0C++o3oIbc=
 github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8 h1:UUHMLvzt/31azWTN/ifGWef4WUqvXk0iRqdhdy/2uzI=
 github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/mgo v0.0.0-20190418114320-e9d4866cb7fc h1:IPMNsbvNOepHFWLz/nXtd7NZvXtHgW9YIvJDhUY/9Tc=
@@ -23,8 +24,6 @@ github.com/juju/retry v0.0.0-20180821225755-9058e192b216 h1:/eQL7EJQKFHByJe3DeE8
 github.com/juju/retry v0.0.0-20180821225755-9058e192b216/go.mod h1:OohPQGsr4pnxwD5YljhQ+TZnuVRYpa5irjugL1Yuif4=
 github.com/juju/testing v0.0.0-20191001232224-ce9dec17d28b h1:Rrp0ByJXEjhREMPGTt3aWYjoIsUGCbt21ekbeJcTWv0=
 github.com/juju/testing v0.0.0-20191001232224-ce9dec17d28b/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
-github.com/juju/utils v0.0.0-20200116185830-d40c2fe10647 h1:wQpkHVbIIpz1PCcLYku9KFWsJ7aEMQXHBBmLy3tRBTk=
-github.com/juju/utils v0.0.0-20200116185830-d40c2fe10647/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20200225001211-e08ecd5f731f h1:aeu5AuhE6Q36esvgpQHEZJCg1owfgWyvmItT6JqFUrM=
 github.com/juju/utils v0.0.0-20200225001211-e08ecd5f731f/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/version v0.0.0-20191219164919-81c1be00b9a6 h1:nrqc9b4YKpKV4lPI3GPPFbo5FUuxkWxgZE2Z8O4lgaw=
@@ -42,6 +41,7 @@ github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a h1:3QH7VyOaaiUHNrA9Se4YQIRkDTCw1EJls9xTUCaCeRM=
 github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a/go.mod h1:4r5QyqhjIWCcK8DO4KMclc5Iknq5qVBAlbYYzAbUScQ=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d h1:9FCpayM9Egr1baVnV1SX0H87m+XB0B8S0hAMi99X/3U=
@@ -60,8 +60,6 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/juju/names.v3 v3.0.0-20200131033104-139ecaca454c h1:bIm6Pj4kEQZhKLruDKfdlB6jZ04FfX8nOge6CdcEL0w=
 gopkg.in/juju/names.v3 v3.0.0-20200131033104-139ecaca454c/go.mod h1:BUnvpShrNFWsLV3tpb4UwtkDLlAzE2egyY49YS5HHW8=
-gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 h1:VpOs+IwYnYBaFnrNAeB8UUWtL3vEUnzSCL1nVjPhqrw=
-gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
 gopkg.in/retry.v1 v1.0.3 h1:a9CArYczAVv6Qs6VGoLMio99GEs7kY9UzSF9+LD+iGs=
 gopkg.in/retry.v1 v1.0.3/go.mod h1:FJkXmWiMaAo7xB+xhvDF59zhfjDWyzmyAxiT4dB688g=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=


### PR DESCRIPTION
## Description of change

Added Database.ControllerInfo and implemented it for MongoDB, and then added Restorer.CheckRestorable to compare the backup file's metadata and the controller information.

## QA steps

Try to restore a backup created from a different controller, it should be rejected by the precheck.

Restoring a backup created from the same controller is allowed.

