### PR TITLE
Run mongorestore to load the dump into the database

### DIFF
--- a/backup/file.go
+++ b/backup/file.go
@@ -26,6 +26,7 @@ const (
 	topLevelDir  = "juju-backup"
 	rootTarFile  = "root.tar"
 	metadataFile = "juju-backup/metadata.json"
+	dumpDir      = "juju-backup/dump"
 	logsDir      = "juju-backup/dump/logs"
 	modelsFile   = "juju-backup/dump/juju/models.bson"
 )
@@ -124,6 +125,11 @@ func (b *expandedBackup) countModels() (int, error) {
 		}
 		count++
 	}
+}
+
+// DumpDirectory returns the path of the contained database dump.
+func (b *expandedBackup) DumpDirectory() string {
+	return filepath.Join(b.dir, dumpDir)
 }
 
 // Close is part of core.BackupFile. It removes the temp directory the

--- a/backup/file_test.go
+++ b/backup/file_test.go
@@ -132,3 +132,18 @@ func (s *backupSuite) TestMetadataFormatVersion2(c *gc.C) {
 	_, err = opened.Metadata()
 	c.Assert(err, gc.ErrorMatches, "reading metadata: unsupported backup format version 2")
 }
+
+func (s *backupSuite) TestDumpDirectory(c *gc.C) {
+	path := filepath.Join("testdata", "valid-backup-ver-1.tar.gz")
+	opened, err := backup.Open(path, s.dir)
+	c.Assert(err, jc.ErrorIsNil)
+	defer opened.Close()
+
+	// Get the name of the tempdir the zip was opened in.
+	items, err := ioutil.ReadDir(s.dir)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(items, gc.HasLen, 1)
+	dirName := items[0].Name()
+
+	c.Assert(opened.DumpDirectory(), gc.Equals, filepath.Join(s.dir, dirName, "juju-backup/dump"))
+}

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -47,11 +47,12 @@ type restoreCommand struct {
 	username string
 	password string
 
-	verbose       bool
-	loggingConfig string
-	backupFile    string
-	tempRoot      string
-	restoreLog    string
+	verbose              bool
+	loggingConfig        string
+	backupFile           string
+	tempRoot             string
+	restoreLog           string
+	includeStatusHistory bool
 
 	connect    func(info db.DialInfo) (core.Database, error)
 	openBackup func(path, tempRoot string) (core.BackupFile, error)
@@ -97,7 +98,8 @@ func (c *restoreCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.manualAgentControl, "manual-agent-control", false, "operator manages secondary controller nodes in HA, e.g stops/starts Juju and Mongo agents")
 	f.BoolVar(&c.restart, "rs", false, "REMOVE ME")
 	f.StringVar(&c.tempRoot, "temp-root", "/tmp", "location to unpack backup file")
-	f.StringVar(&c.restoreLog, "restore-log", "restore.log", "Location to write mongorestore logging output")
+	f.StringVar(&c.restoreLog, "restore-log", "restore.log", "location to write mongorestore logging output")
+	f.BoolVar(&c.includeStatusHistory, "include-status-history", false, "restore status history for machines and units (can be large)")
 }
 
 // Init is part of cmd.Command.
@@ -220,7 +222,7 @@ func (c *restoreCommand) restore() error {
 	}
 	c.ui.Notify("\nRunning restore...\n")
 	c.ui.Notify(fmt.Sprintf("Detailed mongorestore output in %s.\n", c.restoreLog))
-	if err := c.restorer.Restore(c.restoreLog); err != nil {
+	if err := c.restorer.Restore(c.restoreLog, c.includeStatusHistory); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -551,11 +551,17 @@ func (f *fakeControllerNode) StartAgent() error {
 type fakeBackup struct {
 	testing.Stub
 	metadataF func() (core.BackupMetadata, error)
+	dumpDirF  func() string
 }
 
 func (b *fakeBackup) Metadata() (core.BackupMetadata, error) {
 	b.Stub.MethodCall(b, "Metadata")
 	return b.metadataF()
+}
+
+func (b *fakeBackup) DumpDirectory() string {
+	b.Stub.MethodCall(b, "DumpDirectory")
+	return b.dumpDirF()
 }
 
 func (b *fakeBackup) Close() error {

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -494,8 +494,8 @@ func (d *testDatabase) ControllerInfo() (core.ControllerInfo, error) {
 	return d.controllerInfoF()
 }
 
-func (d *testDatabase) RestoreFromDump(dumpDir, logFile string) error {
-	d.Stub.MethodCall(d, "RestoreFromDump", dumpDir, logFile)
+func (d *testDatabase) RestoreFromDump(dumpDir, logFile string, includeStatusHistory bool) error {
+	d.Stub.MethodCall(d, "RestoreFromDump", dumpDir, logFile, includeStatusHistory)
 	return d.Stub.NextErr()
 }
 

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -20,6 +20,11 @@ type Database interface {
 	// can compare to the backup file.
 	ControllerInfo() (ControllerInfo, error)
 
+	// RestoreFromDump restores the database dump in the directory
+	// passed in to the database and writes progress logging to the
+	// specified path.
+	RestoreFromDump(dumpDir string, logFile string) error
+
 	// Close terminates the database connection.
 	Close()
 }

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -128,6 +128,10 @@ type BackupFile interface {
 	// and returns it.
 	Metadata() (BackupMetadata, error)
 
+	// DumpDirectory returns the path of the database dump to be
+	// restored.
+	DumpDirectory() string
+
 	// Close indicates the backup file is not needed anymore so any
 	// temp space used can be freed.
 	Close() error

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -23,7 +23,7 @@ type Database interface {
 	// RestoreFromDump restores the database dump in the directory
 	// passed in to the database and writes progress logging to the
 	// specified path.
-	RestoreFromDump(dumpDir string, logFile string) error
+	RestoreFromDump(dumpDir string, logFile string, includeStatusHistory bool) error
 
 	// Close terminates the database connection.
 	Close()

--- a/core/restorer.go
+++ b/core/restorer.go
@@ -238,8 +238,9 @@ func (r *Restorer) CheckRestorable() (*PrecheckResult, error) {
 
 // Restore replaces the database's contents with the data from the
 // backup's database dump.
-func (r *Restorer) Restore(logPath string) error {
-	return errors.Trace(r.db.RestoreFromDump(r.backup.DumpDirectory(), logPath))
+func (r *Restorer) Restore(logPath string, includeStatusHistory bool) error {
+	err := r.db.RestoreFromDump(r.backup.DumpDirectory(), logPath, includeStatusHistory)
+	return errors.Trace(err)
 }
 
 func versionsMatchExcludingBuild(a, b version.Number) bool {

--- a/core/restorer.go
+++ b/core/restorer.go
@@ -236,6 +236,12 @@ func (r *Restorer) CheckRestorable() (*PrecheckResult, error) {
 	}, nil
 }
 
+// Restore replaces the database's contents with the data from the
+// backup's database dump.
+func (r *Restorer) Restore(logPath string) error {
+	return errors.Trace(r.db.RestoreFromDump(r.backup.DumpDirectory(), logPath))
+}
+
 func versionsMatchExcludingBuild(a, b version.Number) bool {
 	a.Build = 0
 	b.Build = 0

--- a/core/restorer_test.go
+++ b/core/restorer_test.go
@@ -540,6 +540,11 @@ func (db *fakeDatabase) ControllerInfo() (core.ControllerInfo, error) {
 	return db.controllerInfoF()
 }
 
+func (db *fakeDatabase) RestoreFromDump(dumpDir, logFile string) error {
+	db.Stub.MethodCall(db, "RestoreFromDump", dumpDir, logFile)
+	return db.Stub.NextErr()
+}
+
 func (db *fakeDatabase) Close() {
 	db.Stub.MethodCall(db, "Close")
 }

--- a/core/restorer_test.go
+++ b/core/restorer_test.go
@@ -572,11 +572,17 @@ func (f *fakeControllerNode) StartAgent() error {
 type fakeBackup struct {
 	testing.Stub
 	metadataF func() (core.BackupMetadata, error)
+	dumpDirF  func() string
 }
 
 func (b *fakeBackup) Metadata() (core.BackupMetadata, error) {
 	b.Stub.MethodCall(b, "Metadata")
 	return b.metadataF()
+}
+
+func (b *fakeBackup) DumpDirectory() string {
+	b.Stub.MethodCall(b, "DumpDirectory")
+	return b.dumpDirF()
 }
 
 func (b *fakeBackup) Close() error {

--- a/db/mongo.go
+++ b/db/mongo.go
@@ -6,9 +6,13 @@ package db
 import (
 	"crypto/tls"
 	"net"
+	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/replicaset"
 	"github.com/juju/version"
 	"gopkg.in/mgo.v2"
@@ -16,6 +20,8 @@ import (
 
 	"github.com/juju/juju-restore/core"
 )
+
+var logger = loggo.GetLogger("juju-restore.db")
 
 // DialInfo holds information needed to connect to the database.
 type DialInfo struct {
@@ -45,12 +51,13 @@ func Dial(args DialInfo) (core.Database, error) {
 	// We need to set preference to nearest since we're connecting
 	// directly, not to all the nodes in the replicaset.
 	session.SetMode(readPreferenceNearest, false)
-	return &database{session: session}, nil
+	return &database{session: session, info: args}, nil
 }
 
 const readPreferenceNearest = 6
 
 type database struct {
+	info    DialInfo
 	session *mgo.Session
 }
 
@@ -159,6 +166,40 @@ func (db *database) ControllerInfo() (core.ControllerInfo, error) {
 
 	result.Series = allSeriesNames[0]
 	return result, nil
+}
+
+const restoreBinary = "mongorestore"
+
+func (db *database) buildRestoreArgs(dumpPath string) []string {
+	return []string{
+		"-vvvvv",
+		"--drop",
+		"--writeConcern=majority",
+		"--host", db.info.Hostname,
+		"--port", db.info.Port,
+		"--authenticationDatabase=admin",
+		"--username", db.info.Username,
+		"--password", db.info.Password,
+		"--ssl",
+		"--sslAllowInvalidCertificates",
+		"--stopOnError",
+		"--maintainInsertionOrder",
+		"--nsExclude=logs.*",
+		dumpPath,
+	}
+}
+
+func (db *database) RestoreFromDump(dumpDir, logFile string) error {
+	command := exec.Command(restoreBinary, db.buildRestoreArgs(dumpDir)...)
+	logger.Debugf("running restore command: %s %s", command.Path, strings.Join(command.Args, " "))
+	dest, err := os.Create(logFile)
+	if err != nil {
+		return errors.Annotatef(err, "opening logfile %q", logFile)
+	}
+	defer dest.Close()
+	command.Stdout = dest
+	command.Stderr = dest
+	return errors.Annotatef(command.Run(), "running %s", restoreBinary)
 }
 
 // Close is part of core.Database.


### PR DESCRIPTION
## Description of change

Adds Backup.DumpDirectory and Database.RestoreFromDump. Runs mongorestore to load the dump into the database.

## QA steps

Take backup.
Change model (by adding or removing units or machines).
Restore backup. The database should be restored to its original state (although once the controller agents are back up Juju might complain about missing or extraneous machines).


