### PR TITLE
Support downgrading by restoring backup from a previous Juju version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ agent's config file: `/var/lib/juju/agents/machine-<n>/agent.conf`
 They can be specified manually with the `--username`/`--password`
 options if needed.
 
+By default, a backup taken from an earlier Juju version can't be
+restored to prevent downgrading the controller accidentally. If this
+is needed (to back out an upgrade that's hitting an error of some kind
+for example) pass the `--allow-downgrade` option to override the
+version check. (Restoring a backup from a future version of Juju is
+still forbidden.)
+
 The other connection options (hostname, port and ssl) have defaults
 that should be correct unless there is some unusual configuration for
 this MongoDB instance.
@@ -24,8 +31,9 @@ For additional logging, run with `--verbose`.
 ## Current status
 
 This is in development. At the moment it only supports restoring a
-backup to the same controller running the same Juju version. It's
-still experimental at this stage and shouldn't be relied on in
+backup to the same controller, so it can't be used in a disaster
+scenario where all the controller machines are lost. It's still
+experimental at this stage and shouldn't be relied on in
 production. That said: if you have a staging controller that you can
 experiment on, and you'd be alright with rebuilding it in the case of
 catastrophic failure, it would really help us to find bugs if you'd
@@ -34,10 +42,8 @@ try it out and let the Juju team know.
 (We haven't had any controller-destroying failures like that in our
 testing so far.)
 
-The next step is to enable restoring a backup from the same controller
-and an earlier Juju version (to enable rolling back upgrades). After
-that is the disaster recovery scenario of restoring a backup into a
-new controller.
+The next piece of work is to support the disaster recovery scenario of
+restoring a backup into a new controller.
 
 ## Contacting us
 

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -40,7 +40,7 @@ Do you want 'juju-restore' to manage these agents automatically? (y/N): `
 
 	backupFileTemplate = `
 You are about to restore a controller from a backup file taken on {{.BackupDate}}. 
-It contains a controller {{.ControllerModelUUID}} at Juju version {{.JujuVersion}} with {{.ModelCount}} models.
+It contains a controller {{.ControllerModelUUID}} at Juju version {{.BackupJujuVersion}} with {{.ModelCount}} models.
 `
 
 	preChecksCompleted = `
@@ -60,6 +60,9 @@ To stop the agents, login into each secondary controller and run:
 func populate(aTemplate string, data interface{}) string {
 	t := template.Must(template.New("fragment").Parse(aTemplate))
 	content := bytes.Buffer{}
-	t.Execute(&content, data)
+	err := t.Execute(&content, data)
+	if err != nil {
+		logger.Errorf("creating user message: %v", err)
+	}
 	return content.String()
 }

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -52,7 +52,9 @@ type restoreCommand struct {
 	converter   func(member core.ReplicaSetMember) core.ControllerNode
 	readOneChar func(*cmd.Context) (string, error)
 	loadCreds   func() (string, string, error)
-	devMode     bool
+
+	allowDowngrade bool
+	devMode        bool
 
 	hostname string
 	port     string
@@ -107,6 +109,7 @@ func (c *restoreCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.tempRoot, "temp-root", "/tmp", "location to unpack backup file")
 	f.StringVar(&c.restoreLog, "restore-log", "restore.log", "location to write mongorestore logging output")
 	f.BoolVar(&c.includeStatusHistory, "include-status-history", false, "restore status history for machines and units (can be large)")
+	f.BoolVar(&c.allowDowngrade, "allow-downgrade", false, "allow restoring a backup from an older Juju version")
 	if c.devMode {
 		f.BoolVar(&c.restart, "rs", false, "just restart agents that were stopped (JUJU_RESTORE_DEV_MODE)")
 	}
@@ -195,7 +198,7 @@ func (c *restoreCommand) runPreChecks() error {
 	}
 	c.ui.Notify(dbHealthComplete)
 
-	precheckResult, err := c.restorer.CheckRestorable()
+	precheckResult, err := c.restorer.CheckRestorable(c.allowDowngrade)
 	if err != nil {
 		return errors.Annotate(err, "precheck")
 	}

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -611,6 +611,11 @@ func (f *fakeControllerNode) StartAgent() error {
 	return f.NextErr()
 }
 
+func (f *fakeControllerNode) UpdateAgentVersion(target version.Number) error {
+	f.Stub.MethodCall(f, "UpdateAgentVersion", target)
+	return f.NextErr()
+}
+
 type fakeBackup struct {
 	testing.Stub
 	metadataF func() (core.BackupMetadata, error)

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -103,6 +103,10 @@ type ControllerNode interface {
 
 	// StartAgent starts jujud-machine-* service on the controller node.
 	StartAgent() error
+
+	// UpdateAgentVersion changes the tools symlink and agent.conf for
+	// this machine to match the specified version.
+	UpdateAgentVersion(version.Number) error
 }
 
 // PrecheckResult contains the results of a pre-check run.

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -114,8 +114,14 @@ type PrecheckResult struct {
 	// backup was taken.
 	ControllerModelUUID string
 
-	// JujuVersion is the Juju version of the controller from which backup was taken.
-	JujuVersion version.Number
+	// BackupJujuVersion is the Juju version of the controller from which backup was taken.
+	BackupJujuVersion version.Number
+
+	// ControllerJujuVersion is the Juju version of the controller
+	// we're restoring into. If it's greater than BackupJujuVersion
+	// (disregarding build number) then restoring this version is also
+	// a downgrade.
+	ControllerJujuVersion version.Number
 
 	// ModelCount is the count of models that this backup contains.
 	ModelCount int

--- a/core/restorer.go
+++ b/core/restorer.go
@@ -4,6 +4,8 @@
 package core
 
 import (
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/juju/clock"
@@ -102,7 +104,9 @@ func (r *Restorer) CheckSecondaryControllerNodes() map[string]error {
 func (r *Restorer) StopAgents(stopSecondaries bool) map[string]error {
 	// When stopping agents we want to stop primary last in an attempt to
 	// avoid re-election now - we are stopping anyway.
-	return r.manageAgents(stopSecondaries, func(n ControllerNode) error { return n.StopAgent() }, false)
+	return r.manageAgents(stopSecondaries, false, func(n ControllerNode) error {
+		return n.StopAgent()
+	})
 }
 
 // StartAgents starts controller agents, jujud-machine-*.
@@ -114,7 +118,9 @@ func (r *Restorer) StartAgents(startSecondaries bool) map[string]error {
 	r.replicaSetStabilised()
 	// When starting agents we want to start primary first in an attempt to
 	// preserve it being a primary.
-	return r.manageAgents(startSecondaries, func(n ControllerNode) error { return n.StartAgent() }, true)
+	return r.manageAgents(startSecondaries, true, func(n ControllerNode) error {
+		return n.StartAgent()
+	})
 }
 
 func (r *Restorer) replicaSetStabilised() {
@@ -160,7 +166,7 @@ func (r *Restorer) replicaSetStabilised() {
 	}
 }
 
-func (r *Restorer) manageAgents(all bool, operation func(n ControllerNode) error, primaryFirst bool) map[string]error {
+func (r *Restorer) manageAgents(all bool, primaryFirst bool, operation func(n ControllerNode) error) map[string]error {
 	var primary ControllerNode
 	result := map[string]error{}
 	secondaries := []ControllerNode{}
@@ -213,6 +219,8 @@ func (r *Restorer) CheckRestorable(allowDowngrade bool) (*PrecheckResult, error)
 			)
 
 		}
+	} else if backupVersion.Compare(controllerVersion) == -1 {
+		return nil, errors.Errorf("restoring backup would downgrade from juju %q to %q - pass --allow-downgrade if this is intended", controllerVersion, backupVersion)
 	} else if controllerVersion != backupVersion {
 		return nil, errors.Errorf("juju versions don't match - backup: %q, controller: %q",
 			backup.JujuVersion,
@@ -253,8 +261,47 @@ func (r *Restorer) CheckRestorable(allowDowngrade bool) (*PrecheckResult, error)
 // Restore replaces the database's contents with the data from the
 // backup's database dump.
 func (r *Restorer) Restore(logPath string, includeStatusHistory bool) error {
-	err := r.db.RestoreFromDump(r.backup.DumpDirectory(), logPath, includeStatusHistory)
-	return errors.Trace(err)
+	controller, err := r.db.ControllerInfo()
+	if err != nil {
+		return errors.Annotate(err, "getting controller info")
+	}
+	metadata, err := r.backup.Metadata()
+	if err != nil {
+		return errors.Annotatef(err, "getting backup metadata")
+	}
+	logger.Debugf("restoring dump")
+	err = r.db.RestoreFromDump(r.backup.DumpDirectory(), logPath, includeStatusHistory)
+	if err != nil {
+		return errors.Annotatef(err, "restoring dump from %q", r.backup.DumpDirectory())
+	}
+	if controller.JujuVersion != metadata.JujuVersion {
+		logger.Debugf("updating controller agent versions to %s", metadata.JujuVersion)
+		results := r.manageAgents(true, true, func(n ControllerNode) error {
+			logger.Debugf("    %s", n)
+			err := n.UpdateAgentVersion(metadata.JujuVersion)
+			return errors.Annotatef(err, "updating %s", n)
+		})
+		if err := collectMachineErrors(results); err != nil {
+			return errors.Annotatef(err, "problems updating controllers to version %q", metadata.JujuVersion)
+		}
+	}
+	return nil
+}
+
+func collectMachineErrors(results map[string]error) error {
+	var messages []string
+	for _, err := range results {
+		if err == nil {
+			continue
+		}
+		messages = append(messages, err.Error())
+	}
+	if len(messages) == 0 {
+		return nil
+	}
+	// Ensure they're reported in a consistent order.
+	sort.Strings(messages)
+	return errors.Errorf(strings.Join(messages, "\n"))
 }
 
 func versionsMatchExcludingBuild(a, b version.Number) bool {

--- a/core/restorer_test.go
+++ b/core/restorer_test.go
@@ -686,6 +686,11 @@ func (f *fakeControllerNode) StartAgent() error {
 	return f.NextErr()
 }
 
+func (f *fakeControllerNode) UpdateAgentVersion(target version.Number) error {
+	f.Stub.MethodCall(f, "UpdateAgentVersion", target)
+	return f.NextErr()
+}
+
 type fakeBackup struct {
 	testing.Stub
 	metadataF func() (core.BackupMetadata, error)

--- a/machine/commandrunner.go
+++ b/machine/commandrunner.go
@@ -6,7 +6,12 @@ package machine
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/juju/errors"
 )
@@ -18,6 +23,7 @@ type CommandRunner interface {
 	//     to run 'echo hi:D', pass in "echo", "hi:D",
 	//     to stop juju-db, pass in "systemctl", "stop", "juju-db".
 	Run(commands ...string) (string, error)
+	RunScript(script string, args ...string) (string, error)
 }
 
 type localRunner struct{}
@@ -29,20 +35,26 @@ func NewLocalRunner() CommandRunner {
 
 // Run implements CommandRunner.Run.
 func (r *localRunner) Run(commands ...string) (string, error) {
-	// Since we are logged in as a 'ubuntu' user,
-	// we need to run in sudo to switch to 'root' user to elevate privileges.
 	customSSH := exec.Command(commands[0], commands[1:]...)
-	var out bytes.Buffer
+	var out, cmdErr bytes.Buffer
 	customSSH.Stdout = &out
-	cmdErr := bytes.Buffer{}
 	customSSH.Stderr = &cmdErr
 	if err := customSSH.Run(); err != nil {
 		if cmdErr.Len() > 0 {
-			return "", errors.New(cmdErr.String())
+			// Remove trailing newlines from the output.
+			return "", errors.New(strings.TrimSpace(cmdErr.String()))
 		}
 		return "", err
 	}
 	return out.String(), nil
+}
+
+// RunScript for a local machine can still just run the string
+// directly.
+func (r *localRunner) RunScript(script string, args ...string) (string, error) {
+	fullArgs := []string{"sudo", "bash", "-c", script, "local-script"}
+	fullArgs = append(fullArgs, args...)
+	return r.Run(fullArgs...)
 }
 
 type remoteRunner struct {
@@ -57,14 +69,59 @@ func NewRemoteRunner(ip string) CommandRunner {
 
 // Run implements CommandRunner.Run.
 func (r *remoteRunner) Run(commands ...string) (string, error) {
+	// Since we are logged in as a 'ubuntu' user,
+	// we need to run in sudo to read the identity file.
 	args := []string{
 		"sudo",
 		"ssh",
 		"-o", "StrictHostKeyChecking no",
-		"-t", "-t", // twice to force tty allocation, even if ssh jas no local tty
-		"-i", "/var/lib/juju/system-identity", // only root can read /var/lib/juju/system-identity
+		"-i", "/var/lib/juju/system-identity",
 		fmt.Sprintf("ubuntu@%v", r.ip),
+		strings.Join(commands, " "), // The commands should be sent to the target as one string.
 	}
-	args = append(args, commands...)
 	return r.localRunner.Run(args...)
+}
+
+// RunScript on a remote machine needs to scp the script over and then
+// run it.
+func (r *remoteRunner) RunScript(script string, args ...string) (string, error) {
+	scriptFile, err := ioutil.TempFile("/tmp", "juju-restore-script")
+	if err != nil {
+		return "", errors.Annotate(err, "creating tempfile")
+	}
+	defer func() {
+		_ = scriptFile.Close()
+		_ = os.Remove(scriptFile.Name())
+	}()
+	_, err = io.WriteString(scriptFile, script)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	err = scriptFile.Close()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	err = r.scpTempScript(filepath.Base(scriptFile.Name()))
+	if err != nil {
+		return "", errors.Annotatef(err, "scping script to %s", r.ip)
+	}
+	fullArgs := []string{"sudo", "bash", scriptFile.Name()}
+	fullArgs = append(fullArgs, args...)
+	return r.Run(fullArgs...)
+}
+
+// copyTempScript copies a script file from /tmp locally to /tmp on
+// the target.
+func (r *remoteRunner) scpTempScript(name string) error {
+	path := filepath.Join("/tmp", name)
+	args := []string{
+		"sudo",
+		"scp",
+		"-o", "StrictHostKeyChecking no",
+		"-i", "/var/lib/juju/system-identity",
+		path,
+		fmt.Sprintf("ubuntu@%s:%s", r.ip, path),
+	}
+	_, err := r.localRunner.Run(args...)
+	return errors.Trace(err)
 }

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/version"
 
 	"github.com/juju/juju-restore/core"
 )
@@ -26,6 +27,9 @@ func ControllerNodeForReplicaSetMember(member core.ReplicaSetMember) core.Contro
 	return New(ip, member.JujuMachineID, runner)
 }
 
+// Machine represents a juju controller machine and holds a runner for
+// running commands on that machine (whether it's the current machine
+// or a different one).
 type Machine struct {
 	ip string
 
@@ -39,39 +43,44 @@ func New(ip string, jujuID string, runner CommandRunner) *Machine {
 }
 
 // IP implements ControllerNode.IP.
-func (r *Machine) IP() string {
-	return r.ip
+func (m *Machine) IP() string {
+	return m.ip
+}
+
+// String reports "machine n (ip)".
+func (m *Machine) String() string {
+	return fmt.Sprintf("machine %s (%s)", m.jujuID, m.ip)
 }
 
 // Ping implements ControllerNode.Ping()
 // by ssh'ing into the machine and executing an 'echo' command.
-func (r *Machine) Ping() error {
-	command := fmt.Sprintf("hello from %v", r.IP())
-	out, err := r.command.Run("echo", command)
+func (m *Machine) Ping() error {
+	message := fmt.Sprintf("hello from %v", m.IP())
+	out, err := m.command.Run("echo", message)
 	if err != nil {
 		return err
 	}
-	// echo will add a carriage return, \r\n
-	expectedOut := fmt.Sprintf("%v\r\n", command)
+	// echo will add a carriage return, \n
+	expectedOut := fmt.Sprintf("%v\n", message)
 	if out != expectedOut {
-		return errors.Errorf("ping controller machine %v failed: expected %q, got %q", r.IP(), expectedOut, out)
+		return errors.Errorf("ping controller machine %v failed: expected %q, got %q", m.IP(), expectedOut, out)
 	}
 	return nil
 }
 
 // StopAgent implements ControllerNode.StopAgent.
-func (r *Machine) StopAgent() error {
-	return r.ctrlAgent("stop")
+func (m *Machine) StopAgent() error {
+	return m.ctrlAgent("stop")
 }
 
 // StartAgent implements ControllerNode.StartAgent.
-func (r *Machine) StartAgent() error {
-	return r.ctrlAgent("start")
+func (m *Machine) StartAgent() error {
+	return m.ctrlAgent("start")
 }
 
-func (r *Machine) ctrlAgent(op string) error {
-	command := []string{"sudo", "systemctl", op, fmt.Sprintf("jujud-machine-%v", r.jujuID)}
-	out, err := r.command.Run(command...)
+func (m *Machine) ctrlAgent(op string) error {
+	command := []string{"sudo", "systemctl", op, fmt.Sprintf("jujud-machine-%v", m.jujuID)}
+	out, err := m.command.Run(command...)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -80,3 +89,29 @@ func (r *Machine) ctrlAgent(op string) error {
 	}
 	return nil
 }
+
+// UpdateAgentVersion edits the agent.conf and updates the symlink to
+// point to the tools for the specified version.
+func (m *Machine) UpdateAgentVersion(targetVersion version.Number) error {
+	out, err := m.command.RunScript(updateAgentVersionScript, m.jujuID, targetVersion.String())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if out != "" {
+		return errors.Errorf("update agent script shouldn't have returned any output but got %v", out)
+	}
+	return nil
+}
+
+const updateAgentVersionScript = `
+set -e
+cd /var/lib/juju/tools
+target_tools_dir=$(ls -1d $2-*-* | head -n 1)
+if [ ! -d "$target_tools_dir" ]; then
+    echo "no tools directory for version $2, can't downgrade"
+    exit 1
+fi
+ln -s --no-dereference --force "$target_tools_dir" "machine-$1"
+cd "/var/lib/juju/agents/machine-$1"
+sed --in-place=.bkup "s/^upgradedToVersion:.*$/upgradedToVersion: $2/1" agent.conf
+`


### PR DESCRIPTION
## Description of change

Change the validation checks to allow restoring a backup taken before upgrading a Juju controller if the `--allow-downgrade` option is passed. This is off by default to prevent an operator from accidentally downgrading.

When we detect that the restore will downgrade the controller, we run a script on each controller machine which:
* Updates the tools symlink for the machine agent to point to the correct binary version.
* Edits the agent.conf for the machine agent to set `upgradedToVersion` to the right value. This is to prevent the controller agent from trying to run database upgrade steps.

## QA steps

* Bootstrap a 2.7.5 controller, enable HA and deploy some applications.
* Take a backup of the controller:
```sh
juju create-backup -m controller
```
* Upgrade the controller and model to a later version.
```sh
juju upgrade-controller
juju upgrade-model
```
* scp the backup and `juju-restore` binary to the mongo primary controller node.
```sh
juju scp -m controller juju-restore juju-backup-<timestamp>.tar.gz 0:
```
* Run `juju-restore` on the machine.
```sh
# sudo is required until a follow-up PR makes the autoloading credentials work without it.
sudo ./juju-restore juju-backup-<timestamp>.tar.gz
# Complains because backup is from previous version.
sudo ./juju-restore juju-backup-<timestamp>.tar.gz --allow-downgrade
```
* Downgrade works, controller agents and model machine and unit agents are all the old version.