### PR TITLE
Don't require that juju-restore be run with sudo

### DIFF
--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -11,12 +11,11 @@ import (
 const (
 	restoreDoc = `
 
-juju-restore must be executed on the MongoDB primary host of a Juju
-controller.
+juju-restore must be executed on the MongoDB primary host of a Juju controller.
 
-The command will check the state of the target database and the
-details of the backup file provided, and restore the contents of the
-backup into the controller database.
+The command will check the state of the target database and the details of the 
+backup file provided, and restore the contents of the backup into the 
+controller database.
 
 `
 
@@ -26,11 +25,9 @@ Running on primary HA node ✓
 `
 
 	releaseAgentsControl = `
-This controller is in HA and to restore into it successfully, 
-'juju-restore' needs to manage Juju and Mongo agents on  
-secondary controller nodes.
-However, on the bigger systems, the operator might want to manage 
-these agents manually.
+This controller is in HA and to restore into it successfully, 'juju-restore' 
+needs to manage Juju and Mongo agents on secondary controller nodes.
+However on bigger systems the user might want to manage these agents manually.
 
 Do you want 'juju-restore' to manage these agents automatically? (y/N): `
 
@@ -39,8 +36,11 @@ Do you want 'juju-restore' to manage these agents automatically? (y/N): `
 `
 
 	backupFileTemplate = `
-You are about to restore a controller from a backup file taken on {{.BackupDate}}. 
-It contains a controller {{.ControllerModelUUID}} at Juju version {{.BackupJujuVersion}} with {{.ModelCount}} models.
+You are about to restore this backup:
+    Created at:   {{.BackupDate}}
+    Controller:   {{.ControllerModelUUID}}
+    Juju version: {{.BackupJujuVersion}}
+    Models:       {{.ModelCount}}
 `
 
 	preChecksCompleted = `
@@ -53,7 +53,7 @@ Are you sure you want to proceed? (y/N): `
 	secondaryAgentsMustStop = `
 Juju agents on secondary controller machines must be stopped by this point.
 To stop the agents, login into each secondary controller and run:
-    $ systemctl stop jujud-machine-*
+    $ sudo systemctl stop jujud-machine-*
 `
 )
 

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -148,8 +148,11 @@ Checking database and replica set health...
 Replica set is healthy     ✓
 Running on primary HA node ✓
 
-You are about to restore a controller from a backup file taken on 2020-03-17 16:28:24 +0000 UTC. 
-It contains a controller how-bizarre at Juju version 2.7.5 with 3 models.
+You are about to restore this backup:
+    Created at:   2020-03-17 16:28:24 +0000 UTC
+    Controller:   how-bizarre
+    Juju version: 2.7.5
+    Models:       3
 
 All restore pre-checks are completed.
 
@@ -198,8 +201,11 @@ Checking database and replica set health...
 Replica set is healthy     ✓
 Running on primary HA node ✓
 
-You are about to restore a controller from a backup file taken on 2020-03-17 16:28:24 +0000 UTC. 
-It contains a controller how-bizarre at Juju version 2.7.5 with 3 models.
+You are about to restore this backup:
+    Created at:   2020-03-17 16:28:24 +0000 UTC
+    Controller:   how-bizarre
+    Juju version: 2.7.5
+    Models:       3
 
 All restore pre-checks are completed.
 
@@ -263,14 +269,15 @@ Checking database and replica set health...
 Replica set is healthy     ✓
 Running on primary HA node ✓
 
-You are about to restore a controller from a backup file taken on 2020-03-17 16:28:24 +0000 UTC. 
-It contains a controller how-bizarre at Juju version 2.7.5 with 3 models.
+You are about to restore this backup:
+    Created at:   2020-03-17 16:28:24 +0000 UTC
+    Controller:   how-bizarre
+    Juju version: 2.7.5
+    Models:       3
 
-This controller is in HA and to restore into it successfully, 
-'juju-restore' needs to manage Juju and Mongo agents on  
-secondary controller nodes.
-However, on the bigger systems, the operator might want to manage 
-these agents manually.
+This controller is in HA and to restore into it successfully, 'juju-restore' 
+needs to manage Juju and Mongo agents on secondary controller nodes.
+However on bigger systems the user might want to manage these agents manually.
 
 Do you want 'juju-restore' to manage these agents automatically? (y/N): 
 
@@ -297,14 +304,15 @@ Checking database and replica set health...
 Replica set is healthy     ✓
 Running on primary HA node ✓
 
-You are about to restore a controller from a backup file taken on 2020-03-17 16:28:24 +0000 UTC. 
-It contains a controller how-bizarre at Juju version 2.7.5 with 3 models.
+You are about to restore this backup:
+    Created at:   2020-03-17 16:28:24 +0000 UTC
+    Controller:   how-bizarre
+    Juju version: 2.7.5
+    Models:       3
 
-This controller is in HA and to restore into it successfully, 
-'juju-restore' needs to manage Juju and Mongo agents on  
-secondary controller nodes.
-However, on the bigger systems, the operator might want to manage 
-these agents manually.
+This controller is in HA and to restore into it successfully, 'juju-restore' 
+needs to manage Juju and Mongo agents on secondary controller nodes.
+However on bigger systems the user might want to manage these agents manually.
 
 Do you want 'juju-restore' to manage these agents automatically? (y/N): 
 
@@ -333,14 +341,15 @@ Checking database and replica set health...
 Replica set is healthy     ✓
 Running on primary HA node ✓
 
-You are about to restore a controller from a backup file taken on 2020-03-17 16:28:24 +0000 UTC. 
-It contains a controller how-bizarre at Juju version 2.7.5 with 3 models.
+You are about to restore this backup:
+    Created at:   2020-03-17 16:28:24 +0000 UTC
+    Controller:   how-bizarre
+    Juju version: 2.7.5
+    Models:       3
 
-This controller is in HA and to restore into it successfully, 
-'juju-restore' needs to manage Juju and Mongo agents on  
-secondary controller nodes.
-However, on the bigger systems, the operator might want to manage 
-these agents manually.
+This controller is in HA and to restore into it successfully, 'juju-restore' 
+needs to manage Juju and Mongo agents on secondary controller nodes.
+However on bigger systems the user might want to manage these agents manually.
 
 Do you want 'juju-restore' to manage these agents automatically? (y/N): 
 All restore pre-checks are completed.
@@ -367,12 +376,15 @@ Checking database and replica set health...
 Replica set is healthy     ✓
 Running on primary HA node ✓
 
-You are about to restore a controller from a backup file taken on 2020-03-17 16:28:24 +0000 UTC. 
-It contains a controller how-bizarre at Juju version 2.7.5 with 3 models.
+You are about to restore this backup:
+    Created at:   2020-03-17 16:28:24 +0000 UTC
+    Controller:   how-bizarre
+    Juju version: 2.7.5
+    Models:       3
 
 Juju agents on secondary controller machines must be stopped by this point.
 To stop the agents, login into each secondary controller and run:
-    $ systemctl stop jujud-machine-*
+    $ sudo systemctl stop jujud-machine-*
 
 All restore pre-checks are completed.
 
@@ -412,12 +424,15 @@ Checking database and replica set health...
 Replica set is healthy     ✓
 Running on primary HA node ✓
 
-You are about to restore a controller from a backup file taken on 2020-03-17 16:28:24 +0000 UTC. 
-It contains a controller how-bizarre at Juju version 2.7.5 with 3 models.
+You are about to restore this backup:
+    Created at:   2020-03-17 16:28:24 +0000 UTC
+    Controller:   how-bizarre
+    Juju version: 2.7.5
+    Models:       3
 
 Juju agents on secondary controller machines must be stopped by this point.
 To stop the agents, login into each secondary controller and run:
-    $ systemctl stop jujud-machine-*
+    $ sudo systemctl stop jujud-machine-*
 
 All restore pre-checks are completed.
 


### PR DESCRIPTION
## Description of change

We already sudo to run ssh to other controller nodes (for access to system-identity) and to edit config files and symlinks locally. This changes the code that reads creds from the machine agent config file to use sudo as well.

## QA steps

Bootstrap a controller, take a backup, scp that and juju-restore to the primary controller machine.
Run `./juju-restore juju-backup-<timestamp>.tar.gz` - it should successfully get the credentials to connect to the database without requiring the user to run it under sudo.
(Make sure there isn't an old restore.log owned by root in the current dir.)
