### PR TITLE
Add database snapshotting to juju-restore

### DIFF
--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -55,6 +55,12 @@ Juju agents on secondary controller machines must be stopped by this point.
 To stop the agents, login into each secondary controller and run:
     $ sudo systemctl stop jujud-machine-*
 `
+
+	discardSnapshotsFailed = `
+Failed discard database snapshots on some controller machines.
+To remove them manually, ssh to the controller and run:
+    $ sudo rm -r /var/lib/juju/db-snapshot-*
+`
 )
 
 func populate(aTemplate string, data interface{}) string {

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -216,10 +216,12 @@ Stopping Juju agents...
  
     one-node ✓ 
 
+Snapshotting database...
 Running restore...
 Detailed mongorestore output in restore.log.
 
 Database restore complete.
+Database snapshots discarded.
 Starting Juju agents...
  
     one-node ✓ 
@@ -395,10 +397,12 @@ Stopping Juju agents...
  
     one:node ✓ 
 
+Snapshotting database...
 Running restore...
 Detailed mongorestore output in restore.log.
 
 Database restore complete.
+Database snapshots discarded.
 Starting Juju agents...
  
     one:node ✓ 
@@ -458,7 +462,6 @@ func (s *restoreSuite) TestRestoreStartAgents(c *gc.C) {
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 Connecting to database...
-
 Starting Juju agents...
  
     one-node ✓ 
@@ -479,7 +482,6 @@ func (s *restoreSuite) TestRestoreStartAgentsInHA(c *gc.C) {
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 Connecting to database...
-
 Starting Juju agents...
  
     one:node ✓  
@@ -618,6 +620,11 @@ func (d *testDatabase) RestoreFromDump(dumpDir, logFile string, includeStatusHis
 	return d.Stub.NextErr()
 }
 
+func (d *testDatabase) Reconnect() error {
+	d.AddCall("Reconnect")
+	return d.Stub.NextErr()
+}
+
 func (d *testDatabase) Close() {
 	d.AddCall("Close")
 }
@@ -632,18 +639,33 @@ func (f *fakeControllerNode) IP() string {
 	return f.ip
 }
 
-func (f *fakeControllerNode) Ping() error {
-	f.Stub.MethodCall(f, "Ping")
+func (f *fakeControllerNode) Status() (core.NodeStatus, error) {
+	f.Stub.MethodCall(f, "Status")
+	return core.NodeStatus{}, f.NextErr()
+}
+
+func (f *fakeControllerNode) StopService(stype core.ServiceType) error {
+	f.Stub.MethodCall(f, "StopService", stype)
 	return f.NextErr()
 }
 
-func (f *fakeControllerNode) StopAgent() error {
-	f.Stub.MethodCall(f, "StopAgent")
+func (f *fakeControllerNode) StartService(stype core.ServiceType) error {
+	f.Stub.MethodCall(f, "StartService", stype)
 	return f.NextErr()
 }
 
-func (f *fakeControllerNode) StartAgent() error {
-	f.Stub.MethodCall(f, "StartAgent")
+func (f *fakeControllerNode) SnapshotDatabase() (string, error) {
+	f.Stub.MethodCall(f, "SnapshotDatabase")
+	return "", f.NextErr()
+}
+
+func (f *fakeControllerNode) DiscardSnapshot(name string) error {
+	f.Stub.MethodCall(f, "DiscardSnapshot", name)
+	return f.NextErr()
+}
+
+func (f *fakeControllerNode) RestoreSnapshot(name string) error {
+	f.Stub.MethodCall(f, "RestoreSnapshot", name)
 	return f.NextErr()
 }
 

--- a/core/restorer_test.go
+++ b/core/restorer_test.go
@@ -330,7 +330,7 @@ func (s *restorerSuite) TestStopAgentsWithSecondaries(c *gc.C) {
 	})
 	c.Assert(nodes, gc.HasLen, 2)
 	for _, n := range nodes {
-		n.CheckCallNames(c, "IP", "StopAgent")
+		n.CheckCallNames(c, "IP", "StopService")
 	}
 }
 
@@ -347,7 +347,7 @@ func (s *restorerSuite) TestStopAgentsNoSecondaries(c *gc.C) {
 	for _, n := range nodes {
 		// When no secondaries are requested, only primary node will be run
 		if n.IP() == "djula" {
-			n.CheckCallNames(c, "IP", "StopAgent", "IP")
+			n.CheckCallNames(c, "IP", "StopService", "IP")
 		} else {
 			n.CheckCallNames(c, "IP")
 		}
@@ -378,7 +378,7 @@ func (s *restorerSuite) TestStartAgentsWithSecondaries(c *gc.C) {
 	})
 	c.Assert(nodes, gc.HasLen, 2)
 	for _, n := range nodes {
-		n.CheckCallNames(c, "IP", "StartAgent")
+		n.CheckCallNames(c, "IP", "StartService")
 	}
 }
 
@@ -395,7 +395,7 @@ func (s *restorerSuite) TestStartAgentsNoSecondaries(c *gc.C) {
 	for _, n := range nodes {
 		// When no secondaries are requested, only primary node will be run
 		if n.IP() == "djula" {
-			n.CheckCallNames(c, "IP", "StartAgent", "IP")
+			n.CheckCallNames(c, "IP", "StartService", "IP")
 		} else {
 			n.CheckCallNames(c, "IP")
 		}
@@ -788,6 +788,11 @@ func (db *fakeDatabase) RestoreFromDump(dumpDir, logFile string, includeStatusHi
 	return db.Stub.NextErr()
 }
 
+func (db *fakeDatabase) Reconnect() error {
+	db.Stub.MethodCall(db, "Reconnect")
+	return db.Stub.NextErr()
+}
+
 func (db *fakeDatabase) Close() {
 	db.Stub.MethodCall(db, "Close")
 }
@@ -806,18 +811,33 @@ func (f *fakeControllerNode) IP() string {
 	return f.ip
 }
 
-func (f *fakeControllerNode) Ping() error {
-	f.Stub.MethodCall(f, "Ping")
+func (f *fakeControllerNode) Status() (core.NodeStatus, error) {
+	f.Stub.MethodCall(f, "Status")
+	return core.NodeStatus{}, f.NextErr()
+}
+
+func (f *fakeControllerNode) StopService(stype core.ServiceType) error {
+	f.Stub.MethodCall(f, "StopService", stype)
 	return f.NextErr()
 }
 
-func (f *fakeControllerNode) StopAgent() error {
-	f.Stub.MethodCall(f, "StopAgent")
+func (f *fakeControllerNode) StartService(stype core.ServiceType) error {
+	f.Stub.MethodCall(f, "StartService", stype)
 	return f.NextErr()
 }
 
-func (f *fakeControllerNode) StartAgent() error {
-	f.Stub.MethodCall(f, "StartAgent")
+func (f *fakeControllerNode) SnapshotDatabase() (string, error) {
+	f.Stub.MethodCall(f, "SnapshotDatabase")
+	return "", f.NextErr()
+}
+
+func (f *fakeControllerNode) DiscardSnapshot(name string) error {
+	f.Stub.MethodCall(f, "DiscardSnapshot", name)
+	return f.NextErr()
+}
+
+func (f *fakeControllerNode) RestoreSnapshot(name string) error {
+	f.Stub.MethodCall(f, "RestoreSnapshot", name)
 	return f.NextErr()
 }
 

--- a/core/snapshotter.go
+++ b/core/snapshotter.go
@@ -1,0 +1,186 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package core
+
+import "github.com/juju/errors"
+
+// NewSnapshotter returns a new snapshotter to allow taking and
+// restoring/discarding database snapshots.
+func NewSnapshotter(db Database, primary ControllerNode, others []ControllerNode) *Snapshotter {
+	return &Snapshotter{
+		db:        db,
+		primary:   primary,
+		others:    others,
+		snapshots: make(map[string]string),
+	}
+}
+
+// Snapshotter manages database snapshotting across multiple
+// controller nodes.
+type Snapshotter struct {
+	db      Database
+	primary ControllerNode
+	others  []ControllerNode
+
+	// snapshots maps from IP address of each machine to the name of
+	// that machine's snapshot.
+	snapshots map[string]string
+}
+
+func (s *Snapshotter) apply(machines []ControllerNode, f func(ControllerNode) error) error {
+	for _, machine := range machines {
+		err := f(machine)
+		if err != nil {
+			return errors.Annotatef(err, "on %s", machine)
+		}
+	}
+	return nil
+}
+
+func (s *Snapshotter) primaryLast() []ControllerNode {
+	result := append([]ControllerNode{}, s.others...)
+	return append(result, s.primary)
+}
+
+func (s *Snapshotter) primaryFirst() []ControllerNode {
+	result := []ControllerNode{s.primary}
+	return append(result, s.others...)
+}
+
+func (s *Snapshotter) tryRestartAll() {
+	for _, n := range s.primaryFirst() {
+		status, err := n.Status()
+		if err != nil {
+			logger.Errorf("couldn't get status on %s: %s", n, err)
+			continue
+		}
+		if status.DatabaseRunning {
+			continue
+		}
+		err = n.StartService(DatabaseService)
+		if err != nil {
+			logger.Errorf("couldn't restart database on %s: %s", n, err)
+		}
+	}
+}
+
+func (s *Snapshotter) stopAll() error {
+	return errors.Trace(s.apply(s.primaryLast(), func(n ControllerNode) error {
+		return errors.Trace(n.StopService(DatabaseService))
+	}))
+}
+
+func (s *Snapshotter) startAll() error {
+	return errors.Trace(s.apply(s.primaryFirst(), func(n ControllerNode) error {
+		return errors.Trace(n.StartService(DatabaseService))
+	}))
+}
+
+// Snapshot takes a snapshot on each machine (stopping and restarting
+// the database).
+func (s *Snapshotter) Snapshot() (err error) {
+	if len(s.snapshots) != 0 {
+		return errors.Errorf("snapshots have already been created")
+	}
+
+	defer func() {
+		// Make a best-efforts attempt to leave mongo running on the
+		// nodes if something bad happened.
+		if err == nil {
+			return
+		}
+		s.tryRestartAll()
+	}()
+
+	// Stop mongo on each machine.
+	if err := s.stopAll(); err != nil {
+		return errors.Annotate(err, "stopping databases")
+	}
+
+	err = s.apply(s.primaryFirst(), func(n ControllerNode) error {
+		name, err := n.SnapshotDatabase()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		s.snapshots[n.IP()] = name
+		return nil
+	})
+	if err != nil {
+		return errors.Annotate(err, "snapshotting databases")
+	}
+
+	if err := s.startAll(); err != nil {
+		return errors.Annotate(err, "starting databases")
+	}
+	return errors.Annotate(s.db.Reconnect(), "reconnecting to db")
+}
+
+// Discard gets rid of un-needed snapshots.
+func (s *Snapshotter) Discard() error {
+	errs := 0
+	for _, machine := range s.primaryFirst() {
+		name, found := s.snapshots[machine.IP()]
+		if !found {
+			continue
+		}
+		err := machine.DiscardSnapshot(name)
+		if err != nil {
+			logger.Errorf("error discarding snapshot %q on %s: %s", name, machine, err)
+			errs++
+		}
+	}
+	if errs > 0 {
+		return errors.Errorf("errors discarding snapshots: %d", errs)
+	}
+	return nil
+}
+
+// Restore restores the snapshot on all nodes.
+func (s *Snapshotter) Restore() error {
+	if len(s.snapshots) != len(s.others)+1 {
+		return errors.Errorf("not all machines have snapshots so only discarding is allowed")
+	}
+	for _, machine := range s.primaryFirst() {
+		_, found := s.snapshots[machine.IP()]
+		if !found {
+			return errors.Errorf("no snapshot found for %s", machine)
+		}
+	}
+
+	// Stop mongo on each machine.
+	if err := s.stopAll(); err != nil {
+		// Don't leave the databases stopped if we only managed to
+		// stop some.
+		s.tryRestartAll()
+		return errors.Annotate(err, "stopping databases")
+	}
+
+	err := s.apply(s.primaryFirst(), func(n ControllerNode) error {
+		name := s.snapshots[n.IP()]
+		err := n.RestoreSnapshot(name)
+		if err != nil {
+			return errors.Annotatef(err, "restoring snapshot %q", name)
+		}
+		// Restoring the snapshot successfully removes it too - no
+		// need to discard it later.
+		delete(s.snapshots, n.IP())
+		return nil
+	})
+	if err != nil {
+		// If we didn't manage to restore any snapshots then we can
+		// restart the databases.
+		if len(s.snapshots) == len(s.others)+1 {
+			s.tryRestartAll()
+		}
+		// TODO(babbageclunk): What do we do if we've partially
+		// restored the snapshots? Retry until we've managed to
+		// restore all of them or we hit some timeout?
+		return errors.Trace(err)
+	}
+
+	if err := s.startAll(); err != nil {
+		return errors.Annotate(err, "starting databases")
+	}
+	return errors.Annotate(s.db.Reconnect(), "reconnecting to db")
+}

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -5,16 +5,22 @@ package machine
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/version"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju-restore/core"
 )
 
 var logger = loggo.GetLogger("juju-restore.machine")
+
+const (
+	dbPath = "/var/lib/juju"
+)
 
 // ControllerNodeForReplicaSetMember returns ControllerNode for ReplicaSetMember.
 func ControllerNodeForReplicaSetMember(member core.ReplicaSetMember) core.ControllerNode {
@@ -52,40 +58,124 @@ func (m *Machine) String() string {
 	return fmt.Sprintf("machine %s (%s)", m.jujuID, m.ip)
 }
 
-// Ping implements ControllerNode.Ping()
-// by ssh'ing into the machine and executing an 'echo' command.
-func (m *Machine) Ping() error {
-	message := fmt.Sprintf("hello from %v", m.IP())
-	out, err := m.command.Run("echo", message)
+// Status implements ControllerNode.Status() by sshing to it to run a
+// few commands.
+func (m *Machine) Status() (core.NodeStatus, error) {
+	out, err := m.command.RunScript(statusScript)
 	if err != nil {
-		return err
+		return core.NodeStatus{}, err
 	}
-	// echo will add a carriage return, \n
-	expectedOut := fmt.Sprintf("%v\n", message)
-	if out != expectedOut {
-		return errors.Errorf("ping controller machine %v failed: expected %q, got %q", m.IP(), expectedOut, out)
+	var outDoc struct {
+		FreeSpace          int64  `yaml:"free-space"`
+		DatabaseSize       int64  `yaml:"db-size"`
+		DatabaseStatus     string `yaml:"db-status"`
+		MachineAgentStatus string `yaml:"machine-agent-status"`
 	}
-	return nil
+
+	err = yaml.Unmarshal([]byte(out), &outDoc)
+	if err != nil {
+		return core.NodeStatus{}, errors.Annotatef(err, "getting status from %s", m)
+	}
+	return core.NodeStatus{
+		FreeSpace:           outDoc.FreeSpace,
+		DatabaseSize:        outDoc.DatabaseSize,
+		MachineAgentRunning: outDoc.MachineAgentStatus == "active",
+		DatabaseRunning:     outDoc.DatabaseStatus == "active",
+	}, nil
 }
 
-// StopAgent implements ControllerNode.StopAgent.
-func (m *Machine) StopAgent() error {
-	return m.ctrlAgent("stop")
+const statusScript = `
+set -e
+echo free-space: $(df -B1 --output=avail /var/lib/juju/db | tail -1)
+echo db-size: $(du -sB1 /var/lib/juju/db | cut -f 1)
+echo db-status: $(systemctl is-active juju-db.service)
+echo machine-agent-status: $(systemctl is-active jujud-machine-*.service)
+`
+
+// StopService implements ControllerNode.StopService.
+func (m *Machine) StopService(stype core.ServiceType) error {
+	return m.ctrlService("stop", stype)
 }
 
-// StartAgent implements ControllerNode.StartAgent.
-func (m *Machine) StartAgent() error {
-	return m.ctrlAgent("start")
+// StartService implements ControllerNode.StartService.
+func (m *Machine) StartService(stype core.ServiceType) error {
+	return m.ctrlService("start", stype)
 }
 
-func (m *Machine) ctrlAgent(op string) error {
-	command := []string{"sudo", "systemctl", op, fmt.Sprintf("jujud-machine-%v", m.jujuID)}
+func (m *Machine) serviceName(stype core.ServiceType) string {
+	switch stype {
+	case core.MachineAgentService:
+		return fmt.Sprintf("jujud-machine-%v", m.jujuID)
+	case core.DatabaseService:
+		return "juju-db"
+	default:
+		logger.Errorf("unknown service type %q", stype)
+		return "unknown-service"
+	}
+}
+
+func (m *Machine) ctrlService(op string, stype core.ServiceType) error {
+	command := []string{"sudo", "systemctl", op, m.serviceName(stype)}
 	out, err := m.command.Run(command...)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if out != "" {
 		return errors.Errorf("start agent command should not have returned any output, but got %v", out)
+	}
+	return nil
+}
+
+const (
+	snapshotTemplate = "db-snapshot-"
+	snapshotScript   = `
+set -e
+templateBase="$1"
+destDir=$(mktemp -d --tmpdir=/var/lib/juju "${templateBase}XXX")
+cp -r /var/lib/juju/db/* $destDir
+echo $destDir
+`
+)
+
+// SnapshotDatabase is part of core.ControllerNode.
+func (m *Machine) SnapshotDatabase() (string, error) {
+	output, err := m.command.RunScript(snapshotScript, snapshotTemplate)
+	if err != nil {
+		return "", errors.Annotatef(err, "snapshotting database on %s", m)
+	}
+	// Chop off the path and db-snapshot part of the new directory
+	// name - we don't want people to be able to "restore" or discard
+	// arbitrary directories.
+	name := filepath.Base(strings.TrimSpace(output))[len(snapshotTemplate):]
+	return name, nil
+}
+
+// DiscardSnapshot is part of core.ControllerNode.
+func (m *Machine) DiscardSnapshot(name string) error {
+	fullSnapshotPath := fmt.Sprintf("/var/lib/juju/%s%s", snapshotTemplate, name)
+	_, err := m.command.Run("sudo", "rm", "-r", fullSnapshotPath)
+	if err != nil {
+		return errors.Annotatef(err, "discarding snapshot %q on %s", name, m)
+	}
+	return nil
+}
+
+const restoreScript = `
+set -e
+snapshotPath="/var/lib/juju/db-snapshot-$1"
+if [ ! -d "$snapshotPath" ]; then
+    echo "snapshot $snapshotPath not found"
+    exit 1
+fi
+rm -r /var/lib/juju/db
+mv "$snapshotPath" /var/lib/juju/db
+`
+
+// RestoreSnapshot is part of core.ControllerNode.
+func (m *Machine) RestoreSnapshot(name string) error {
+	_, err := m.command.RunScript(restoreScript, name)
+	if err != nil {
+		return errors.Annotatef(err, "restoring snapshot %q on %s", name, m)
 	}
 	return nil
 }


### PR DESCRIPTION
Before restoring the dump in the backup we snapshot the current database by stopping mongo, copying the /var/lib/juju/db directory on all controller machines and restarting it.

If the restore is successful, these snapshots are discarded on each machine. If it fails for some reason, the snapshots are restored by copying the snapshots back to /var/lib/juju/db (after stopping the database).

This isn't complete yet. At the moment we don't take the step of restarting the jujud agents yet after restoring the snapshots in the case of a failed restore. If the restore is also a version downgrade that fails to run the agent update script on some of the nodes, we don't revert the upgrade script on the nodes where it succeeded.

This also needs unit tests for the Snapshotter and the points where it's used.
