### PR TITLE
Use normal (non-raw) standard input for prompts; add --yes option

### DIFF
--- a/cmd/interactions.go
+++ b/cmd/interactions.go
@@ -6,12 +6,10 @@ package cmd
 import (
 	"bufio"
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 // This file contains helper functions for generic operations commonly needed
@@ -30,68 +28,37 @@ func IsUserAbortedError(err error) bool {
 }
 
 // NewUserInteractions constructs user interactions with given context.
-func NewUserInteractions(ctx *cmd.Context, charFunc func(*cmd.Context) (string, error)) *UserInteractions {
-	return &UserInteractions{ctx, charFunc}
+func NewUserInteractions(ctx *cmd.Context) *UserInteractions {
+	return &UserInteractions{
+		ctx:     ctx,
+		scanner: bufio.NewScanner(ctx.Stdin),
+	}
 }
 
 // UserInteractions communicates with the user
 // by providing feedback and by collecting user input.
 type UserInteractions struct {
-	ctx             *cmd.Context
-	readOneCharFunc func(*cmd.Context) (string, error)
-}
-
-func ReadOneChar(ctx *cmd.Context) (string, error) {
-	// fd 0 is stdin
-	state, err := terminal.MakeRaw(0)
-	if err != nil {
-		logger.Errorf("setting stdin to raw:", err)
-		return "", errors.Trace(err)
-	}
-	defer func() {
-		if err := terminal.Restore(0, state); err != nil {
-			logger.Warningf("warning, failed to restore terminal:", err)
-		}
-	}()
-	in := bufio.NewReader(ctx.Stdin)
-	r, _, err := in.ReadRune()
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	// Because we are in raw mode, user response is not visible.
-	// Display user response explicitly to avoid confusion.
-	fmt.Fprintf(ctx.Stdout, fmt.Sprintf("%v\r\n", string(r)))
-	return string(r), nil
+	ctx     *cmd.Context
+	scanner *bufio.Scanner
 }
 
 // UserConfirmYes returns an error if we do not read a "y" or "yes" from user
 // input.
 func (ui *UserInteractions) UserConfirmYes() error {
-	prompt := func() (bool, error) {
-		answer, err := ui.readOneCharFunc(ui.ctx)
-		if err != nil {
-			return false, errors.Trace(err)
-		}
-		lowCased := strings.ToLower(answer)
-		if lowCased == "y" {
-			return true, nil
-		}
-		if lowCased == "n" || lowCased == "\n" || lowCased == "\r" {
-			return true, errors.Trace(userAbortedError("aborted"))
-		}
-		ui.Notify(fmt.Sprintf("Invalid answer %q. Please answer (y/N) or Enter to default to N: ", answer))
-		return false, nil
-	}
-
-	for {
-		proceed, err := prompt()
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if proceed {
+	for ui.scanner.Scan() {
+		s := strings.ToLower(ui.scanner.Text())
+		switch s {
+		case "y", "yes":
 			return nil
+		case "n", "no", "":
+			return errors.Trace(userAbortedError("aborted"))
 		}
+		ui.Notify(fmt.Sprintf("Invalid response %q. Please answer (y/N): ", s))
 	}
+	if ui.scanner.Err() != nil {
+		return errors.Trace(ui.scanner.Err())
+	}
+	return errors.Errorf("no input")
 }
 
 // Notify will post message to an io.Writer of the given cmd.Context.
@@ -99,16 +66,4 @@ func (ui *UserInteractions) UserConfirmYes() error {
 // go consistently to the same writer.
 func (ui *UserInteractions) Notify(message string) {
 	fmt.Fprintf(ui.ctx.Stdout, message)
-}
-
-// byteAtATimeReader causes all reads to return a single byte.  This prevents
-// things line bufio.scanner from reading past the end of a line, which can
-// cause problems when we do wacky things like reading directly from the
-// terminal for password style prompts.
-type byteAtATimeReader struct {
-	io.Reader
-}
-
-func (r byteAtATimeReader) Read(out []byte) (int, error) {
-	return r.Reader.Read(out[:1])
 }

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/lunixbochs/vtclean v1.0.0 // indirect
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
-	golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d
+	golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d // indirect
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
 	gopkg.in/juju/names.v3 v3.0.0-20200131033104-139ecaca454c // indirect

--- a/main.go
+++ b/main.go
@@ -37,7 +37,6 @@ func Run(args []string) int {
 		db.Dial,
 		backup.Open,
 		machine.ControllerNodeForReplicaSetMember,
-		cmd.ReadOneChar,
 		cmd.ReadCredsFromAgentConf,
 		os.Getenv("JUJU_RESTORE_DEV_MODE") == "on",
 	)


### PR DESCRIPTION
For some reason `juju-restore` used raw mode for y/n prompt input, meaning it "took" as soon as you pressed the Y (or N) key, without waiting for enter. This is weird and unlike other prompts (include `juju` prompts), and also means piping `yes` to it fails with an I/O mode error. This PR does two things:

1) Switches it back to normal (non-raw) standard input read mode. This means it waits for enter as expected, and also allows you to pipe `yes` to it.
2) Also add a `--yes` option, meaning "answer 'yes' to confirmation prompts (non-interactive)". This will be useful for testing, and is a bit cleaner than piping `y` to stdin.

## QA steps

Use `juju-restore` and wait for the confirmation prompt.
