### PR TITLE
[JUJU-2333] Add secret backends to copy-controller

### DIFF
--- a/db/mongo.go
+++ b/db/mongo.go
@@ -384,6 +384,10 @@ func (db *database) CopyController(controller core.ControllerInfo) error {
 	if err != nil {
 		return errors.Annotate(err, "copying target external controllers")
 	}
+	err = db.copyCollection("secretBackends", "")
+	if err != nil {
+		return errors.Annotate(err, "copying target secret backends")
+	}
 	err = db.copyPermissions(controller)
 	if err != nil {
 		return errors.Annotate(err, "copying target permissions")
@@ -449,6 +453,7 @@ func (db *database) buildControllerRestoreArgs(dumpPath string) []string {
 		"--nsInclude=juju.globalSettings",
 		"--nsInclude=juju.permissions",
 		"--nsInclude=juju.externalControllers",
+		"--nsInclude=juju.secretBackends",
 	}
 	return append(args, dumpPath)
 }


### PR DESCRIPTION
## Description of change

A small tweak to include the secret backends collection in the copy-controller functionality.

## QA steps

Add a secret backend to a controller and create a backup.
Restore the backup to a new controller with `--copy-controller`
Use the `secret-backends` command to confirm the backend has been restored.

