### PR TITLE
Add secret backend rotation to copy controller

### DIFF
--- a/db/mongo.go
+++ b/db/mongo.go
@@ -388,6 +388,10 @@ func (db *database) CopyController(controller core.ControllerInfo) error {
 	if err != nil {
 		return errors.Annotate(err, "copying target secret backends")
 	}
+	err = db.copyCollection("secretBackendsRotate", "")
+	if err != nil {
+		return errors.Annotate(err, "copying target secret backend rotations")
+	}
 	err = db.copyPermissions(controller)
 	if err != nil {
 		return errors.Annotate(err, "copying target permissions")
@@ -454,6 +458,7 @@ func (db *database) buildControllerRestoreArgs(dumpPath string) []string {
 		"--nsInclude=juju.permissions",
 		"--nsInclude=juju.externalControllers",
 		"--nsInclude=juju.secretBackends",
+		"--nsInclude=juju.secretBackendsRotate",
 	}
 	return append(args, dumpPath)
 }


### PR DESCRIPTION
## Description of change

Add the `secretBackendsRotate` collection to the `--copy-controller` option

## QA steps

Backup a 3.1 controller with secret backends which are set up to rotate tokens.
Run a `juju-restore --copy-controller` and ensure that the backend rotation info is copied.

