### PR TITLE
fix: add missing ssl arg to controller restore

### DIFF
--- a/db/mongo.go
+++ b/db/mongo.go
@@ -455,6 +455,7 @@ func (db *database) buildControllerRestoreArgs(dumpPath, caCertPath, certPath st
 		"--authenticationDatabase=admin",
 		"--username", db.info.Username,
 		"--password", db.info.Password,
+		"--ssl",
 		"--sslCAFile", caCertPath,
 		"--sslPEMKeyFile", certPath,
 		"--sslPEMKeyPassword=ignored",


### PR DESCRIPTION
Adds back the `--ssl` arg to controller restore